### PR TITLE
PT-9132: Identity error value as a separate error parameter

### DIFF
--- a/src/VirtoCommerce.ProfileExperienceApiModule.Core/VirtoCommerce.ProfileExperienceApiModule.Core.csproj
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Core/VirtoCommerce.ProfileExperienceApiModule.Core.csproj
@@ -25,7 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.84.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.257.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/InviteUserCommandHandler.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/InviteUserCommandHandler.cs
@@ -128,7 +128,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
                 }
                 else
                 {
-                    errors.Add(new IdentityErrorInfo{Code = "Role not found", Description = $"Role {roleId} not found"});
+                    errors.Add(new IdentityErrorInfo{Code = "Role not found", Description = $"Role '{roleId}' not found", Parameter = roleId});
                 }
             }
             

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/RegisterRequestCommandHandler.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/RegisterRequestCommandHandler.cs
@@ -220,7 +220,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
                 {
                     Code = x.Code,
                     Description = x.Description,
-                    Parameter = x is CustomIdentityError error ? error.ErrorParameter.ToString() : null
+                    Parameter = x is CustomIdentityError error ? error.Parameter.ToString() : null
                 }).ToList()
             };
         }

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Extensions/IdentityErrorInfoExtensions.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Extensions/IdentityErrorInfoExtensions.cs
@@ -11,7 +11,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Extensions
             var error = new IdentityErrorInfo { Code = x.Code, Description = x.Description };
             if (x is CustomIdentityError customIdentityError)
             {
-                error.ErrorParameter = customIdentityError.ErrorParameter;
+                error.Parameter = customIdentityError.Parameter;
             }
 
             return error;

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Models/IdentityErrorInfo.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Models/IdentityErrorInfo.cs
@@ -1,9 +1,10 @@
+using System;
 using Microsoft.AspNetCore.Identity;
 
 namespace VirtoCommerce.ProfileExperienceApiModule.Data.Models
 {
     public class IdentityErrorInfo : IdentityError
     {
-        public int? ErrorParameter { get; set; }
+        public string Parameter { get; set; }
     }
 }

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Schemas/IdentityErrorInfoType.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Schemas/IdentityErrorInfoType.cs
@@ -8,7 +8,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Schemas
         public IdentityErrorInfoType()
         {
             Field(x => x.Code).Description("Error code");
-            Field(x => x.ErrorParameter, nullable: true).Description("Error parameter");
+            Field(x => x.Parameter, nullable: true).Description("Error parameter");
             Field(x => x.Description, nullable: true).Description("Error description");
         }
     }

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/VirtoCommerce.ProfileExperienceApiModule.Data.csproj
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/VirtoCommerce.ProfileExperienceApiModule.Data.csproj
@@ -32,8 +32,8 @@
     <PackageReference Include="VirtoCommerce.CustomerModule.Core" Version="3.210.0" />
     <PackageReference Include="VirtoCommerce.ExperienceApiModule.Core" Version="3.200.0" />
     <PackageReference Include="VirtoCommerce.MarketingModule.Core" Version="3.200.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.200.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.200.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.257.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.257.0" />
     <PackageReference Include="VirtoCommerce.PricingModule.Core" Version="3.200.0" />
     <PackageReference Include="VirtoCommerce.StoreModule.Core" Version="3.200.0" />
     <PackageReference Include="VirtoCommerce.CoreModule.Core" Version="3.203.0" />

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/VirtoCommerce.ProfileExperienceApiModule.Data.csproj
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/VirtoCommerce.ProfileExperienceApiModule.Data.csproj
@@ -34,6 +34,7 @@
     <PackageReference Include="VirtoCommerce.MarketingModule.Core" Version="3.200.0" />
     <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.257.0" />
     <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.257.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.257.0" />
     <PackageReference Include="VirtoCommerce.PricingModule.Core" Version="3.200.0" />
     <PackageReference Include="VirtoCommerce.StoreModule.Core" Version="3.200.0" />
     <PackageReference Include="VirtoCommerce.CoreModule.Core" Version="3.203.0" />

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Web/module.manifest
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Web/module.manifest
@@ -3,7 +3,7 @@
   <id>VirtoCommerce.ProfileExperienceApiModule</id>
   <version>3.221.0</version>
   <version-tag />
-  <platformVersion>3.200.0</platformVersion>
+  <platformVersion>3.257.0</platformVersion>
   <title>Commerce Profile Experience API module</title>
   <description />
   <authors>


### PR DESCRIPTION
## Description
Identity error value results now have a separate error parameter for identity-related mutations
ErrorParameter renamed to parameter.
![image](https://user-images.githubusercontent.com/9972421/195068876-491d51c8-12fa-4cb6-90b0-4b3902ebd2b6.png)

## References
### QA-test:
### Jira-link:

https://virtocommerce.atlassian.net/browse/PT-9132
### Artifact URL: https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.ProfileExperienceApiModule_3.221.0-pr-29-9691.zip
