### PR TITLE
PT-9582: Address Email can be null or empty or valid address.

### DIFF
--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Validators/AddressValidator.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Validators/AddressValidator.cs
@@ -9,9 +9,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Validators
         public AddressValidator()
         {
             RuleFor(x => x.Email)
-                .NotNull()
-                .NotEmpty()
-                .Must(x => x.IsValidEmail())
+                .Must(x => string.IsNullOrEmpty(x) || x.IsValidEmail())
                 .WithMessage("Invalid email format an the address");
         }
     }


### PR DESCRIPTION
## Description
fix: Address.Email can be null or empty or valid address.

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/PT-9582
### Artifact URL: https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.ProfileExperienceApiModule_3.231.0-pr-39-0076.zip
