### PR TITLE
PT-12940: Resend email confirmation link by userId

### DIFF
--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/CreateUserCommandHandler.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/CreateUserCommandHandler.cs
@@ -24,7 +24,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
             if (result.Succeeded)
             {
                 // Send Email Verification
-                await _mediator.Send(new SendVerifyEmailCommand(request.ApplicationUser.StoreId, string.Empty, request.ApplicationUser.Email), cancellationToken);
+                await _mediator.Send(new SendVerifyEmailCommand(request.ApplicationUser.StoreId, string.Empty, request.ApplicationUser.Email, request.ApplicationUser.Id), cancellationToken);
 
             }
 

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/RegisterRequestCommandHandler.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/RegisterRequestCommandHandler.cs
@@ -301,7 +301,8 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
         {
             return _mediator.Send(new SendVerifyEmailCommand(request.StoreId,
                 request.LanguageCode,
-                email), tokenSource.Token);
+                email,
+                string.Empty), tokenSource.Token);
         }
 
         private static string ResolveEmail(ApplicationUser account, IList<Address> orgAddresses)

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/SendVerifyEmailCommand.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/SendVerifyEmailCommand.cs
@@ -4,13 +4,19 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
 {
     public class SendVerifyEmailCommand : ICommand<bool>
     {
-        public SendVerifyEmailCommand(string storeId, string languageCode, string email)
+        public SendVerifyEmailCommand()
+        {
+        }
+
+        public SendVerifyEmailCommand(string storeId, string languageCode, string email, string userId)
         {
             StoreId = storeId;
             LanguageCode = languageCode;
             Email = email;
+            UserId = userId;
         }
 
+        public string UserId { get; set; }
         public string Email { get; set; }
         public string StoreId { get; set; }
         public string LanguageCode { get; set; }

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/SendVerifyEmailCommandHandler.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/SendVerifyEmailCommandHandler.cs
@@ -40,17 +40,26 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
         {
             using (var userManager = _userManagerFactory())
             {
-                var user = await userManager.FindByEmailAsync(request.Email);
+                ApplicationUser user = null;
+
+                if (!string.IsNullOrEmpty(request.UserId))
+                {
+                    user = await userManager.FindByIdAsync(request.UserId);
+                }
+                else if (!string.IsNullOrEmpty(request.Email))
+                {
+                    user = await userManager.FindByEmailAsync(request.Email);
+                }
 
                 if (user == null || user.StoreId != request.StoreId)
                 {
-                    return true;
+                    return false;
                 }
 
                 var store = await _storeService.GetByIdAsync(request.StoreId);
                 if (store == null)
                 {
-                    return true;
+                    return false;
                 }
 
                 var settingDescriptor = StoreSettings.EmailVerificationEnabled;

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Schemas/InputSendVerifyEmailType.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Schemas/InputSendVerifyEmailType.cs
@@ -9,6 +9,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Schemas
             Field<NonNullGraphType<StringGraphType>>("storeId", "Store ID");
             Field<StringGraphType>("languageCode", "Notification language code");
             Field<StringGraphType>("email");
+            Field<StringGraphType>("userId");
         }
     }
 }

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Schemas/ProfileSchema.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Schemas/ProfileSchema.cs
@@ -404,6 +404,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Schemas
                             var isAuthenticated = ((GraphQLUserContext)context.UserContext).User?.Identity?.IsAuthenticated ?? false;
                             if (isAuthenticated)
                             {
+                                command.UserId = context.GetCurrentUserId();
                                 command.Email = await GetUserEmailAsync(context.GetCurrentUserId());
                             }
 


### PR DESCRIPTION
## Description
feat: Resend email confirmation link by userId in sendVerifyEmail command. If userId is specified, email property will be ignored. If a user is authorized then userId and email will be taken from the current profile.

## References
### QA-test:
### Jira-link:
### Artifact URL:
