### PR TITLE
PT-13171: ResetPasswordEmailNotification and RegistrationInvitationEmailNotification ignored Store customization.

### DIFF
--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/InviteUserCommandHandler.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/InviteUserCommandHandler.cs
@@ -153,7 +153,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
             var user = await userManager.FindByEmailAsync(email);
             var token = await userManager.GeneratePasswordResetTokenAsync(user);
 
-            var notification = await _notificationSearchService.GetNotificationAsync<RegistrationInvitationEmailNotification>();
+            var notification = await _notificationSearchService.GetNotificationAsync<RegistrationInvitationEmailNotification>(new TenantIdentity(store.Id, nameof(Store)));
             notification.InviteUrl = $"{store.Url.TrimLastSlash()}{request.UrlSuffix.NormalizeUrlSuffix()}?userId={user.Id}&email={HttpUtility.UrlEncode(user.Email)}&token={Uri.EscapeDataString(token)}";
             notification.Message = request.Message;
             notification.To = user.Email;

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Queries/RequestPasswordResetQueryHandler.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Queries/RequestPasswordResetQueryHandler.cs
@@ -9,6 +9,7 @@ using VirtoCommerce.NotificationsModule.Core.Types;
 using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Platform.Core.Security;
 using VirtoCommerce.ProfileExperienceApiModule.Data.Extensions;
+using VirtoCommerce.StoreModule.Core.Model;
 using VirtoCommerce.StoreModule.Core.Services;
 
 namespace VirtoCommerce.ProfileExperienceApiModule.Data.Queries
@@ -47,7 +48,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Queries
                 {
                     var token = await userManager.GeneratePasswordResetTokenAsync(user);
 
-                    var notification = await _notificationSearchService.GetNotificationAsync<ResetPasswordEmailNotification>();
+                    var notification = await _notificationSearchService.GetNotificationAsync<ResetPasswordEmailNotification>(new TenantIdentity(store.Id, nameof(Store)));
                     notification.Url = $"{store.Url.TrimLastSlash()}{request.UrlSuffix.NormalizeUrlSuffix()}?userId={user.Id}&token={Uri.EscapeDataString(token)}";
                     notification.To = user.Email;
                     notification.From = store.Email;


### PR DESCRIPTION
## Description
fix: ResetPasswordEmailNotification and RegistrationInvitationEmailNotification ignored Store customization.

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/PT-13171
### Artifact URL: https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.ProfileExperienceApiModule_3.405.0-pr-56-e12d.zip
