### PR TITLE
PT-13765: registration from Checkout

### DIFF
--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Authorization/ProfileAuthorizationHandler.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Authorization/ProfileAuthorizationHandler.cs
@@ -167,12 +167,16 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Authorization
                 updatePersonalDataCommand.UserId = currentUserId;
                 result = true;
             }
-            else if (context.Resource is InviteUserCommand inviteUserCommand && currentContact != null)
+            else if (context.Resource is InviteUserCommand inviteUserCommand)
             {
-                if (!string.IsNullOrEmpty(inviteUserCommand.OrganizationId))
+                if (!string.IsNullOrEmpty(inviteUserCommand.OrganizationId) && currentContact != null)
                 {
                     var currentUser = await userManager.FindByIdAsync(currentUserId);
                     result = currentContact.Organizations.Contains(inviteUserCommand.OrganizationId) && currentUser.StoreId.EqualsInvariant(inviteUserCommand.StoreId);
+                }
+                else
+                {
+                    result = true;
                 }
             }
             else if (context.Resource is LockOrganizationContactCommand lockOrganizationContact)

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Authorization/ProfileAuthorizationHandler.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Authorization/ProfileAuthorizationHandler.cs
@@ -169,12 +169,10 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Authorization
             }
             else if (context.Resource is InviteUserCommand inviteUserCommand && currentContact != null)
             {
-                var currentUser = await userManager.FindByIdAsync(currentUserId);
-
-                result = currentUser.StoreId.EqualsInvariant(inviteUserCommand.StoreId);
-                if (result && inviteUserCommand.OrganizationId != null)
+                if (!string.IsNullOrEmpty(inviteUserCommand.OrganizationId))
                 {
-                    result = currentContact.Organizations.Contains(inviteUserCommand.OrganizationId);
+                    var currentUser = await userManager.FindByIdAsync(currentUserId);
+                    result = currentContact.Organizations.Contains(inviteUserCommand.OrganizationId) && currentUser.StoreId.EqualsInvariant(inviteUserCommand.StoreId);
                 }
             }
             else if (context.Resource is LockOrganizationContactCommand lockOrganizationContact)

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Authorization/ProfileAuthorizationHandler.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Authorization/ProfileAuthorizationHandler.cs
@@ -170,7 +170,12 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Authorization
             else if (context.Resource is InviteUserCommand inviteUserCommand && currentContact != null)
             {
                 var currentUser = await userManager.FindByIdAsync(currentUserId);
-                result = currentContact.Organizations.Contains(inviteUserCommand.OrganizationId) && currentUser.StoreId.EqualsInvariant(inviteUserCommand.StoreId);
+
+                result = currentUser.StoreId.EqualsInvariant(inviteUserCommand.StoreId);
+                if (result && inviteUserCommand.OrganizationId != null)
+                {
+                    result = currentContact.Organizations.Contains(inviteUserCommand.OrganizationId);
+                }
             }
             else if (context.Resource is LockOrganizationContactCommand lockOrganizationContact)
             {

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/InviteUserCommand.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/InviteUserCommand.cs
@@ -16,5 +16,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
         public string Message { get; set; }
 
         public string[] RoleIds { get; set; }
+
+        public string CustomerOrderId { get; set; }
     }
 }

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/RegisterByInvitationCommand.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/RegisterByInvitationCommand.cs
@@ -18,5 +18,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
         public string Username { get; set; }
 
         public string Password { get; set; }
+
+        public string CustomerOrderId { get; set; }
     }
 }

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/RegisterRequestCommandHandler.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/RegisterRequestCommandHandler.cs
@@ -124,11 +124,9 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
             EmailVerificationFlow = CurrentStore.GetEmailVerificationFlow();
 
             // Read Settings
-            DefaultContactStatus = CurrentStore.Settings
-                .GetSettingValue<string>(CustomerSettings.ContactDefaultStatus.Name, null);
+            DefaultContactStatus = CurrentStore.Settings.GetValue<string>(CustomerSettings.ContactDefaultStatus);
 
-            DefaultOrganizationStatus = CurrentStore.Settings
-                .GetSettingValue<string>(CustomerSettings.OrganizationDefaultStatus.Name, null);
+            DefaultOrganizationStatus = CurrentStore.Settings.GetValue<string>(CustomerSettings.OrganizationDefaultStatus);
 
             MaintainerRole = await GetMaintainerRole(result, tokenSource);
         }

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/SendVerifyEmailCommandHandler.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/SendVerifyEmailCommandHandler.cs
@@ -62,7 +62,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
                     return true;
                 }
 
-                if (store.Settings.GetSettingValue(StoreSettings.EmailVerificationEnabled.Name, (bool)StoreSettings.EmailVerificationEnabled.DefaultValue))
+                if (store.Settings.GetValue<bool>(StoreSettings.EmailVerificationEnabled))
                 {
                     await SendConfirmationEmailNotificationAsync(store, user, request.LanguageCode);
                 }

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Extensions/StoreExtensions.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Extensions/StoreExtensions.cs
@@ -8,8 +8,8 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Extensions
     {
         public static string GetEmailVerificationFlow(this Store store)
         {
-            var emailVerificationEnabled = store.Settings.GetSettingValue(StoreSettings.EmailVerificationEnabled.Name, (bool)StoreSettings.EmailVerificationEnabled.DefaultValue);
-            var emailVerificationRequired = store.Settings.GetSettingValue(StoreSettings.EmailVerificationRequired.Name, (bool)StoreSettings.EmailVerificationRequired.DefaultValue);
+            var emailVerificationEnabled = store.Settings.GetValue<bool>(StoreSettings.EmailVerificationEnabled);
+            var emailVerificationRequired = store.Settings.GetValue<bool>(StoreSettings.EmailVerificationRequired);
 
             if (!emailVerificationEnabled)
             {

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Schemas/InputInviteUserType.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Schemas/InputInviteUserType.cs
@@ -8,11 +8,12 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Schemas
         public InputInviteUserType()
         {
             Field<NonNullGraphType<StringGraphType>>(nameof(InviteUserCommand.StoreId), "ID of store which will send invites");
-            Field<NonNullGraphType<StringGraphType>>(nameof(InviteUserCommand.OrganizationId), "ID of organization where contact will be added for user");
+            Field<StringGraphType>(nameof(InviteUserCommand.OrganizationId), "ID of organization where contact will be added for user");
             Field<StringGraphType>(nameof(InviteUserCommand.UrlSuffix), "Optional URL suffix: you may provide here relative URL to your page which handle registration by invite");
             Field<NonNullGraphType<ListGraphType<NonNullGraphType<StringGraphType>>>>(nameof(InviteUserCommand.Emails), "Emails which will receive invites");
             Field<StringGraphType>(nameof(InviteUserCommand.Message), "Optional message to include into email with instructions which invites persons will see");
             Field<ListGraphType<NonNullGraphType<StringGraphType>>>(nameof(InviteUserCommand.RoleIds), "Role IDs or names to be assigned to the invited user");
+            Field<StringGraphType>(nameof(InviteUserCommand.CustomerOrderId), "Customer order Id to be associated with this user.");
         }
     }
 }

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Schemas/InputRegisterByInvitationType.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Schemas/InputRegisterByInvitationType.cs
@@ -14,6 +14,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Schemas
             Field<StringGraphType>(nameof(RegisterByInvitationCommand.Phone), "Phone");
             Field<NonNullGraphType<StringGraphType>>(nameof(RegisterByInvitationCommand.Username), "Username");
             Field<NonNullGraphType<StringGraphType>>(nameof(RegisterByInvitationCommand.Password), "Password");
+            Field<StringGraphType>(nameof(RegisterByInvitationCommand.CustomerOrderId), "Customer order Id to be associated with this user.");
         }
     }
 }

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/VirtoCommerce.ProfileExperienceApiModule.Data.csproj
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/VirtoCommerce.ProfileExperienceApiModule.Data.csproj
@@ -21,8 +21,8 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="VirtoCommerce.CoreModule.Core" Version="3.400.0" />
     <PackageReference Include="VirtoCommerce.CustomerModule.Core" Version="3.400.0" />
-    <PackageReference Include="VirtoCommerce.ExperienceApiModule.Core" Version="3.421.0" />
-    <PackageReference Include="VirtoCommerce.ExperienceApiModule.XOrder" Version="3.421.0" />
+    <PackageReference Include="VirtoCommerce.ExperienceApiModule.Core" Version="3.422.0" />
+    <PackageReference Include="VirtoCommerce.ExperienceApiModule.XOrder" Version="3.422.0" />
     <PackageReference Include="VirtoCommerce.MarketingModule.Core" Version="3.400.0" />
     <PackageReference Include="VirtoCommerce.NotificationsModule.Core" Version="3.403.0" />
     <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.413.0" />

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/VirtoCommerce.ProfileExperienceApiModule.Data.csproj
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/VirtoCommerce.ProfileExperienceApiModule.Data.csproj
@@ -21,10 +21,10 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="VirtoCommerce.CoreModule.Core" Version="3.400.0" />
     <PackageReference Include="VirtoCommerce.CustomerModule.Core" Version="3.400.0" />
-    <PackageReference Include="VirtoCommerce.ExperienceApiModule.Core" Version="3.420.0-alpha.1249-pt-13765" />
-    <PackageReference Include="VirtoCommerce.ExperienceApiModule.XOrder" Version="3.420.0-alpha.1249-pt-13765" />
+    <PackageReference Include="VirtoCommerce.ExperienceApiModule.Core" Version="3.421.0" />
+    <PackageReference Include="VirtoCommerce.ExperienceApiModule.XOrder" Version="3.421.0" />
     <PackageReference Include="VirtoCommerce.MarketingModule.Core" Version="3.400.0" />
-    <PackageReference Include="VirtoCommerce.NotificationsModule.Core" Version="3.403.0-alpha.344-pt-13765" />
+    <PackageReference Include="VirtoCommerce.NotificationsModule.Core" Version="3.403.0" />
     <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.413.0" />
     <PackageReference Include="VirtoCommerce.PricingModule.Core" Version="3.400.0" />
     <PackageReference Include="VirtoCommerce.StoreModule.Core" Version="3.401.0" />

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/VirtoCommerce.ProfileExperienceApiModule.Data.csproj
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/VirtoCommerce.ProfileExperienceApiModule.Data.csproj
@@ -21,10 +21,11 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="VirtoCommerce.CoreModule.Core" Version="3.400.0" />
     <PackageReference Include="VirtoCommerce.CustomerModule.Core" Version="3.400.0" />
-    <PackageReference Include="VirtoCommerce.ExperienceApiModule.Core" Version="3.411.0" />
+    <PackageReference Include="VirtoCommerce.ExperienceApiModule.Core" Version="3.420.0-alpha.1249-pt-13765" />
+    <PackageReference Include="VirtoCommerce.ExperienceApiModule.XOrder" Version="3.420.0-alpha.1249-pt-13765" />
     <PackageReference Include="VirtoCommerce.MarketingModule.Core" Version="3.400.0" />
-    <PackageReference Include="VirtoCommerce.NotificationsModule.Core" Version="3.400.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.400.0" />
+    <PackageReference Include="VirtoCommerce.NotificationsModule.Core" Version="3.403.0-alpha.344-pt-13765" />
+    <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.413.0" />
     <PackageReference Include="VirtoCommerce.PricingModule.Core" Version="3.400.0" />
     <PackageReference Include="VirtoCommerce.StoreModule.Core" Version="3.401.0" />
     <PackageReference Include="VirtoCommerce.TaxModule.Core" Version="3.400.0" />

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Web/module.manifest
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Web/module.manifest
@@ -7,9 +7,9 @@
   <dependencies>
     <dependency id="VirtoCommerce.Core" version="3.400.0" />
     <dependency id="VirtoCommerce.Customer" version="3.400.0" />
-    <dependency id="VirtoCommerce.ExperienceApi" version="3.420.0-alpha.1249-pt-13765" />
+    <dependency id="VirtoCommerce.ExperienceApi" version="3.421.0" />
     <dependency id="VirtoCommerce.Marketing" version="3.400.0" />
-    <dependency id="VirtoCommerce.Notifications" version="3.403.0-alpha.344-pt-13765" />
+    <dependency id="VirtoCommerce.Notifications" version="3.403.0" />
     <dependency id="VirtoCommerce.Pricing" version="3.400.0" />
     <dependency id="VirtoCommerce.Store" version="3.401.0" />
     <dependency id="VirtoCommerce.Tax" version="3.400.0" />

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Web/module.manifest
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Web/module.manifest
@@ -7,7 +7,7 @@
   <dependencies>
     <dependency id="VirtoCommerce.Core" version="3.400.0" />
     <dependency id="VirtoCommerce.Customer" version="3.400.0" />
-    <dependency id="VirtoCommerce.ExperienceApi" version="3.421.0" />
+    <dependency id="VirtoCommerce.ExperienceApi" version="3.422.0" />
     <dependency id="VirtoCommerce.Marketing" version="3.400.0" />
     <dependency id="VirtoCommerce.Notifications" version="3.403.0" />
     <dependency id="VirtoCommerce.Pricing" version="3.400.0" />

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Web/module.manifest
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Web/module.manifest
@@ -3,13 +3,13 @@
   <id>VirtoCommerce.ProfileExperienceApiModule</id>
   <version>3.410.0</version>
   <version-tag />
-  <platformVersion>3.400.0</platformVersion>
+  <platformVersion>3.413.0</platformVersion>
   <dependencies>
     <dependency id="VirtoCommerce.Core" version="3.400.0" />
     <dependency id="VirtoCommerce.Customer" version="3.400.0" />
-    <dependency id="VirtoCommerce.ExperienceApi" version="3.411.0" />
+    <dependency id="VirtoCommerce.ExperienceApi" version="3.420.0-alpha.1249-pt-13765" />
     <dependency id="VirtoCommerce.Marketing" version="3.400.0" />
-    <dependency id="VirtoCommerce.Notifications" version="3.400.0" />
+    <dependency id="VirtoCommerce.Notifications" version="3.403.0-alpha.344-pt-13765" />
     <dependency id="VirtoCommerce.Pricing" version="3.400.0" />
     <dependency id="VirtoCommerce.Store" version="3.401.0" />
     <dependency id="VirtoCommerce.Tax" version="3.400.0" />


### PR DESCRIPTION
## Description

1. `organizationId` field in `inviteUser` mutation arguments is no longer mandatory
2. running `inviteUser` mutaton without `organizationId` sends different email notification - SignUp notification Customer
3. added `customerOrderId` field to `inviteUser` mutation arguments
4. running `inviteUser` with `customerOrderId` adds it to the invite url link in the notification
5. added `customerOrderId` field to `registerByInvitation` mutation arguments
6. running `registerByInvitation` with `customerOrderId` fires `transferOrder` command and associates the order with provided `userId`

## References
### QA-test:
### Jira-link:




https://virtocommerce.atlassian.net/browse/PT-13765
### Artifact URL: https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.ProfileExperienceApiModule_3.410.0-pr-61-e9fa.zip
