### PR TITLE
VCST-1698: add makeAddressDefault mutation

### DIFF
--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Aggregates/MemberAggregateRootBase.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Aggregates/MemberAggregateRootBase.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using VirtoCommerce.CustomerModule.Core.Model;
+using static VirtoCommerce.CoreModule.Core.Common.AddressType;
 
 namespace VirtoCommerce.ProfileExperienceApiModule.Data.Aggregates
 {
@@ -36,10 +37,27 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Aggregates
             {
                 var addressToDelete = Member.Addresses.FirstOrDefault(x => x.Key == address.Key);
 
-                if (addressToDelete != null)
+                if (addressToDelete != null && addressToDelete.AddressType != BillingAndShipping)
                 {
                     Member.Addresses.Remove(addressToDelete);
                 }
+            }
+
+            return this;
+        }
+
+        public virtual MemberAggregateRootBase MakeAddressDefault(string addressKey)
+        {
+            var addressToDefault = Member.Addresses.FirstOrDefault(x => x.Key == addressKey);
+
+            if (addressToDefault != null)
+            {
+                foreach (var address in Member.Addresses.Where(x => x.AddressType == addressToDefault.AddressType))
+                {
+                    address.IsDefault = false;
+                }
+
+                addressToDefault.IsDefault = true;
             }
 
             return this;

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/MakeAddressDefaultCommand.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/MakeAddressDefaultCommand.cs
@@ -1,0 +1,20 @@
+using GraphQL.Types;
+using VirtoCommerce.Xapi.Core.Infrastructure;
+
+namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands;
+
+public class MakeAddressDefaultCommand : ICommand<bool>
+{
+    public string UserId { get; set; }
+    public string MemberId { get; set; }
+    public string AddressId { get; set; }
+}
+
+public class MakeAddressDefaultCommandType : InputObjectGraphType<MakeAddressDefaultCommand>
+{
+    public MakeAddressDefaultCommandType()
+    {
+        Field(x => x.AddressId);
+        Field(x => x.MemberId);
+    }
+}

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/MakeAddressDefaultCommandBuilder.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/MakeAddressDefaultCommandBuilder.cs
@@ -1,0 +1,39 @@
+using System.Threading.Tasks;
+using GraphQL;
+using GraphQL.Types;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using VirtoCommerce.ProfileExperienceApiModule.Data.Services;
+using VirtoCommerce.Xapi.Core.BaseQueries;
+using VirtoCommerce.Xapi.Core.Extensions;
+
+namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands;
+
+public class MakeAddressDefaultCommandBuilder : CommandBuilder<MakeAddressDefaultCommand, bool, MakeAddressDefaultCommandType, BooleanGraphType>
+{
+    protected override string Name => "makeAddressDefault";
+
+    private readonly IProfileAuthorizationService _profileAuthorizationService;
+
+    public MakeAddressDefaultCommandBuilder(
+        IMediator mediator,
+        IAuthorizationService authorizationService,
+        IProfileAuthorizationService profileAuthorizationService)
+        : base(mediator, authorizationService)
+    {
+        _profileAuthorizationService = profileAuthorizationService;
+    }
+
+    protected override MakeAddressDefaultCommand GetRequest(IResolveFieldContext<object> context)
+    {
+        var request = base.GetRequest(context);
+        request.UserId = context.GetCurrentUserId();
+        return request;
+    }
+
+    protected override async Task BeforeMediatorSend(IResolveFieldContext<object> context, MakeAddressDefaultCommand request)
+    {
+        await base.BeforeMediatorSend(context, request);
+        await _profileAuthorizationService.CheckAuthAsync(context, request);
+    }
+}

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/MakeAddressDefaultCommandHandler.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/MakeAddressDefaultCommandHandler.cs
@@ -1,0 +1,25 @@
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using VirtoCommerce.ProfileExperienceApiModule.Data.Aggregates;
+
+namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands;
+
+public class MakeAddressDefaultCommandHandler : IRequestHandler<MakeAddressDefaultCommand, bool>
+{
+    private readonly IMemberAggregateRootRepository _memberAggregateRepository;
+
+    public MakeAddressDefaultCommandHandler(IMemberAggregateRootRepository memberAggregateRepository)
+    {
+        _memberAggregateRepository = memberAggregateRepository;
+    }
+
+    public async Task<bool> Handle(MakeAddressDefaultCommand request, CancellationToken cancellationToken)
+    {
+        var memberAggregate = await _memberAggregateRepository.GetMemberAggregateRootByIdAsync<MemberAggregateRootBase>(request.MemberId);
+        memberAggregate.MakeAddressDefault(request.AddressId);
+        await _memberAggregateRepository.SaveAsync(memberAggregate);
+
+        return true;
+    }
+}


### PR DESCRIPTION
## Description
```js
mutation makeAddressDefault ($command: MakeAddressDefaultCommandType!) {
  makeAddressDefault(command: $command)
}
```
---
```json
{
  "command": {
    "addressId": "60e35036-88a4-4584-9064-72ffd1b86687",
    "memberId": "1da11fb2-0da8-4298-9503-03ef5ce550bb"
  }
}
```

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-1698
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.ProfileExperienceApiModule_3.816.0-pr-88-f349.zip