### PR TITLE
fix: add condition to emails collection for UpdateContactCommand to h…

### DIFF
--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Mapping/ProfileMappingProfile.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Mapping/ProfileMappingProfile.cs
@@ -35,7 +35,8 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Mapping
 
             CreateMap<UpdateContactCommand, Contact>()
                 .ForMember(x => x.DynamicProperties, opt => opt.Ignore())
-                .ForMember(x => x.Addresses, opt => opt.Condition(x => x.Addresses != null));
+                .ForMember(x => x.Addresses, opt => opt.Condition(x => x.Addresses != null))
+                .ForMember(x => x.Emails, opt => opt.Condition(x => x.Emails != null));
 
             CreateMap<RegisteredOrganization, Organization>()
                 .ConvertUsing((input, result) =>

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Mapping/ProfileMappingProfile.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Mapping/ProfileMappingProfile.cs
@@ -36,7 +36,9 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Mapping
             CreateMap<UpdateContactCommand, Contact>()
                 .ForMember(x => x.DynamicProperties, opt => opt.Ignore())
                 .ForMember(x => x.Addresses, opt => opt.Condition(x => x.Addresses != null))
-                .ForMember(x => x.Emails, opt => opt.Condition(x => x.Emails != null));
+                .ForMember(x => x.Groups, opt => opt.Condition(x => x.Groups != null))
+                .ForMember(x => x.Phones, opt => opt.Condition(x => x.Phones != null))
+                .ForMember(x => x.Organizations, opt => opt.Condition(x => x.Organizations != null));
 
             CreateMap<RegisteredOrganization, Organization>()
                 .ConvertUsing((input, result) =>

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Mapping/ProfileMappingProfile.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Mapping/ProfileMappingProfile.cs
@@ -36,6 +36,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Mapping
             CreateMap<UpdateContactCommand, Contact>()
                 .ForMember(x => x.DynamicProperties, opt => opt.Ignore())
                 .ForMember(x => x.Addresses, opt => opt.Condition(x => x.Addresses != null))
+                .ForMember(x => x.Emails, opt => opt.Condition(x => x.Emails != null))
                 .ForMember(x => x.Groups, opt => opt.Condition(x => x.Groups != null))
                 .ForMember(x => x.Phones, opt => opt.Condition(x => x.Phones != null))
                 .ForMember(x => x.Organizations, opt => opt.Condition(x => x.Organizations != null));

--- a/tests/VirtoCommerce.ProfileExperienceApiModule.Tests/Handlers/UpdateContactCommandHandlerTests.cs
+++ b/tests/VirtoCommerce.ProfileExperienceApiModule.Tests/Handlers/UpdateContactCommandHandlerTests.cs
@@ -5,26 +5,40 @@ using AutoFixture;
 using AutoMapper;
 using Moq;
 using VirtoCommerce.CustomerModule.Core.Model;
+using VirtoCommerce.ProfileExperienceApiModule.Data.Aggregates.Contact;
+using VirtoCommerce.ProfileExperienceApiModule.Data.Commands;
+using VirtoCommerce.ProfileExperienceApiModule.Data.Mapping;
 using VirtoCommerce.Xapi.Core.Models;
 using VirtoCommerce.Xapi.Core.Services;
 using VirtoCommerce.Xapi.Tests.Helpers;
-using VirtoCommerce.ProfileExperienceApiModule.Data.Aggregates.Contact;
-using VirtoCommerce.ProfileExperienceApiModule.Data.Commands;
 using Xunit;
 
 namespace VirtoCommerce.ProfileExperienceApiModule.Tests.Handlers
 {
     public class UpdateContactCommandHandlerTests : MoqHelper
     {
+        private readonly IMapper _mapper;
+
+        public UpdateContactCommandHandlerTests()
+        {
+            var configuration = new MapperConfiguration(cfg =>
+            {
+                cfg.AddProfile<ProfileMappingProfile>();
+            });
+
+            _mapper = configuration.CreateMapper();
+        }
+
         [Fact]
         public async Task Handle_RequestWithDynamicProperties_UpdateDynamicPropertyCalled()
         {
             // Arragne
             var aggregateRepositoryMock = new Mock<IContactAggregateRepository>();
             var dynamicPropertyUpdaterServiceMock = new Mock<IDynamicPropertyUpdaterService>();
-            var mapperMock = new Mock<IMapper>();
+
 
             var contact = _fixture.Create<Contact>();
+            contact.Emails = new List<string> { "initial@example.com" };
             var contactAggregae = new ContactAggregate { Member = contact };
 
             aggregateRepositoryMock
@@ -33,14 +47,17 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Tests.Handlers
 
             var handler = new UpdateContactCommandHandler(aggregateRepositoryMock.Object,
                 dynamicPropertyUpdaterServiceMock.Object,
-                mapperMock.Object);
+                _mapper);
 
             var command = _fixture.Create<UpdateContactCommand>();
+            command.Emails = null;
 
             // Act
             var aggregate = await handler.Handle(command, CancellationToken.None);
 
             // Assert
+            Assert.Contains("initial@example.com", contact.Emails);
+
             dynamicPropertyUpdaterServiceMock.Verify(x => x.UpdateDynamicPropertyValues(It.Is<Contact>(x => x == contact),
                 It.Is<IList<DynamicPropertyValue>>(x => x == command.DynamicProperties)), Times.Once);
         }


### PR DESCRIPTION
…andle empty entries

## Description
The current implementation of the `updateContact` mutation inadvertently clears the `emails` collection of a contact when executed. This occurs with the following query:

```graphql
mutation updateContact($command: InputUpdateContactType!) { 
  updateContact(command: $command) { 
    id 
  }
}
```

```json
{
  "command": {
    "firstName": "1st",
    "lastName": "1st",
    "defaultLanguage": "en-US",
    "currencyCode": "USD",
    "phones": ["123-456-7890"],
    "id": "884575d5-f096-4af1-9857-f7b056d1ff44",
    "organizations": ["5787d40a-2702-4553-97a0-07206ec3e917"]
  }
}
```
## References
### QA-test:
### Jira-link:
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.ProfileExperienceApiModule_3.905.0-pr-98-6d61.zip