### PR TITLE
VCST-2869: Email "Reset password link" isn't sent to new Personal users

### DIFF
--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Queries/RequestPasswordResetQueryHandler.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Queries/RequestPasswordResetQueryHandler.cs
@@ -43,7 +43,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Queries
             if (user != null &&
                 !string.IsNullOrEmpty(user.Email) &&
                 !string.IsNullOrEmpty(user.StoreId) &&
-                (!user.LockoutEnd.HasValue || user.LockoutEnd < DateTime.UtcNow))
+                (user.LockoutEnd is null || user.LockoutEnd < DateTime.UtcNow))
             {
                 var store = await _storeService.GetByIdAsync(user.StoreId);
 

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Queries/RequestPasswordResetQueryHandler.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Queries/RequestPasswordResetQueryHandler.cs
@@ -40,7 +40,10 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Queries
             var user = await userManager.FindByNameAsync(request.LoginOrEmail)
                        ?? await userManager.FindByEmailAsync(request.LoginOrEmail);
 
-            if (!string.IsNullOrEmpty(user?.Email) && !string.IsNullOrEmpty(user.StoreId) && user.LockoutEnd < DateTime.UtcNow)
+            if (user != null &&
+                !string.IsNullOrEmpty(user.Email) &&
+                !string.IsNullOrEmpty(user.StoreId) &&
+                (!user.LockoutEnd.HasValue || user.LockoutEnd < DateTime.UtcNow))
             {
                 var store = await _storeService.GetByIdAsync(user.StoreId);
 

--- a/tests/VirtoCommerce.ProfileExperienceApiModule.Tests/Handlers/RequestPasswordResetQueryHandlerTests.cs
+++ b/tests/VirtoCommerce.ProfileExperienceApiModule.Tests/Handlers/RequestPasswordResetQueryHandlerTests.cs
@@ -1,0 +1,122 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Identity;
+using Moq;
+using VirtoCommerce.NotificationsModule.Core.Model;
+using VirtoCommerce.NotificationsModule.Core.Services;
+using VirtoCommerce.NotificationsModule.Core.Types;
+using VirtoCommerce.Platform.Core.Security;
+using VirtoCommerce.ProfileExperienceApiModule.Data.Queries;
+using VirtoCommerce.StoreModule.Core.Model;
+using VirtoCommerce.StoreModule.Core.Services;
+using Xunit;
+
+namespace VirtoCommerce.ProfileExperienceApiModule.Tests.Handlers
+{
+    public class RequestPasswordResetQueryHandlerTests
+    {
+        [Fact]
+        public async Task Handle_UserWithNullLockoutEnd_ScheduleSendNotificationAsyncCalled()
+        {
+            // Arrange
+            var userManagerMock = new Mock<UserManager<ApplicationUser>>(
+                Mock.Of<IUserStore<ApplicationUser>>(), null, null, null, null, null, null, null, null);
+            var notificationSearchServiceMock = new Mock<INotificationSearchService>();
+            var notificationSenderMock = new Mock<INotificationSender>();
+            var storeServiceMock = new Mock<IStoreService>();
+
+            var user = new ApplicationUser
+            {
+                Id = "testUserId",
+                Email = "test@example.com",
+                StoreId = "testStoreId",
+                LockoutEnd = null
+            };
+
+            var store = new Store
+            {
+                Id = "testStoreId",
+                Url = "http://teststore.com",
+                Email = "store@example.com"
+            };
+
+            var notification = new ResetPasswordEmailNotification();
+
+            userManagerMock.Setup(x => x.FindByNameAsync(It.IsAny<string>())).ReturnsAsync(user);
+            userManagerMock.Setup(x => x.GeneratePasswordResetTokenAsync(user)).ReturnsAsync("testToken");
+            storeServiceMock.Setup(x => x.GetAsync(It.IsAny<IList<string>>(), It.IsAny<string>(), It.IsAny<bool>())).ReturnsAsync([store]);
+            notificationSearchServiceMock.Setup(x => x.SearchNotificationsAsync(It.IsAny<NotificationSearchCriteria>())).ReturnsAsync(new NotificationSearchResult { Results = [notification], TotalCount = 1 });
+
+            var handler = new RequestPasswordResetQueryHandler(
+                () => userManagerMock.Object,
+                notificationSearchServiceMock.Object,
+                notificationSenderMock.Object,
+                storeServiceMock.Object);
+
+            var request = new RequestPasswordResetQuery
+            {
+                LoginOrEmail = "test@example.com",
+                UrlSuffix = "/reset-password"
+            };
+
+            // Act
+            await handler.Handle(request, CancellationToken.None);
+
+            // Assert
+            notificationSenderMock.Verify(x => x.ScheduleSendNotificationAsync(It.IsAny<ResetPasswordEmailNotification>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task Handle_UserWithExpiredLockoutEnd_ScheduleSendNotificationAsyncCalled()
+        {
+            // Arrange
+            var userManagerMock = new Mock<UserManager<ApplicationUser>>(
+                Mock.Of<IUserStore<ApplicationUser>>(), null, null, null, null, null, null, null, null);
+            var notificationSearchServiceMock = new Mock<INotificationSearchService>();
+            var notificationSenderMock = new Mock<INotificationSender>();
+            var storeServiceMock = new Mock<IStoreService>();
+
+            var user = new ApplicationUser
+            {
+                Id = "testUserId",
+                Email = "test@example.com",
+                StoreId = "testStoreId",
+                LockoutEnd = DateTime.UtcNow.AddHours(-1)
+            };
+
+            var store = new Store
+            {
+                Id = "testStoreId",
+                Url = "http://teststore.com",
+                Email = "store@example.com"
+            };
+
+            var notification = new ResetPasswordEmailNotification();
+
+            userManagerMock.Setup(x => x.FindByNameAsync(It.IsAny<string>())).ReturnsAsync(user);
+            userManagerMock.Setup(x => x.GeneratePasswordResetTokenAsync(user)).ReturnsAsync("testToken");
+            storeServiceMock.Setup(x => x.GetAsync(It.IsAny<IList<string>>(), It.IsAny<string>(), It.IsAny<bool>())).ReturnsAsync([store]);
+            notificationSearchServiceMock.Setup(x => x.SearchNotificationsAsync(It.IsAny<NotificationSearchCriteria>())).ReturnsAsync(new NotificationSearchResult { Results = [notification], TotalCount = 1 });
+
+            var handler = new RequestPasswordResetQueryHandler(
+                () => userManagerMock.Object,
+                notificationSearchServiceMock.Object,
+                notificationSenderMock.Object,
+                storeServiceMock.Object);
+
+            var request = new RequestPasswordResetQuery
+            {
+                LoginOrEmail = "test@example.com",
+                UrlSuffix = "/reset-password"
+            };
+
+            // Act
+            await handler.Handle(request, CancellationToken.None);
+
+            // Assert
+            notificationSenderMock.Verify(x => x.ScheduleSendNotificationAsync(It.IsAny<ResetPasswordEmailNotification>()), Times.Once);
+        }
+    }
+}


### PR DESCRIPTION
## Description
fix:  Email "Reset password link" isn't sent to new Personal users if LockoutEnd is null.

## References
### QA-test:
### Jira-link:


https://virtocommerce.atlassian.net/browse/VCST-2869
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.ProfileExperienceApiModule_3.906.0-pr-102-a03b.zip