### PR TITLE
fix: NRE in ContactAggregate.set_Member

### DIFF
--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Aggregates/Contact/ContactAggregate.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Aggregates/Contact/ContactAggregate.cs
@@ -20,7 +20,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Aggregates.Contact
                     Contact.FullName = string.Join(" ", Contact.FirstName, Contact.LastName);
                 }
 
-                StoreId = Contact.SecurityAccounts.Select(x => x.StoreId).FirstOrDefault();
+                StoreId = Contact?.SecurityAccounts?.Select(x => x.StoreId).FirstOrDefault();
             }
         }
 


### PR DESCRIPTION
## Description
Code can throw NRE when Contact is null or SecurityAccounts is null
## References
### QA-test:
### Jira-link:
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.ProfileExperienceApiModule_3.913.0-pr-108-df04.zip