### PR TITLE
VCST-3175: Add addresses field to requestRegistration mutation

### DIFF
--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Mapping/ProfileMappingProfile.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Mapping/ProfileMappingProfile.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using VirtoCommerce.CustomerModule.Core.Model;
 using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.ProfileExperienceApiModule.Data.Commands;
@@ -52,9 +53,11 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Mapping
                         null :
                         new List<string> { input.PhoneNumber };
 
-                    result.Addresses = input.Address == null ?
-                            null :
-                            new List<Address> { input.Address };
+                    result.Addresses = input.Addresses?.ToList() ?? [];
+                    if (input.Address != null)
+                    {
+                        result.Addresses.Add(input.Address);
+                    }
 
                     return result;
                 });

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Models/RegisterOrganization/RegisteredOrganization.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Models/RegisterOrganization/RegisteredOrganization.cs
@@ -10,6 +10,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Models.RegisterOrganizat
         public string Description { get; set; }
         public string PhoneNumber { get; set; }
         public Address Address { get; set; }
+        public IList<Address> Addresses { get; set; }
         public IList<DynamicPropertyValue> DynamicProperties { get; set; }
     }
 }

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Schemas/RegisterCompany/InputRegisterOrganizationType.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Schemas/RegisterCompany/InputRegisterOrganizationType.cs
@@ -12,7 +12,8 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Schemas.RegisterCompany
             Field<StringGraphType>("description");
             Field<StringGraphType>("phoneNumber");
             Field<ListGraphType<InputDynamicPropertyValueType>>(nameof(Member.DynamicProperties));
-            Field<InputMemberAddressType>("address");
+            Field<InputMemberAddressType>("address").DeprecationReason("Use \"Addresses\" field. \"Address\" and \"Addresses\" fields will be automatically concatenated.");
+            Field<ListGraphType<InputMemberAddressType>>("addresses");
         }
     }
 }

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Schemas/RegisterCompany/RegisterOrganizationType.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Schemas/RegisterCompany/RegisterOrganizationType.cs
@@ -17,7 +17,8 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Schemas.RegisterCompany
             Field<StringGraphType>("description");
             ExtendableField<MemberAddressType>("address",
                 resolve: context => (context.Source).Addresses?.FirstOrDefault(),
-                description: "Returns first organization address.");
+                description: "Returns first organization address.",
+                deprecationReason: "Use addresses field instead.");
             ExtendableField<ListGraphType<MemberAddressType>>("addresses",
                 resolve: context => (context.Source).Addresses,
                 description: "Organization's addresses");

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Schemas/RegisterCompany/RegisterOrganizationType.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Schemas/RegisterCompany/RegisterOrganizationType.cs
@@ -17,8 +17,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Schemas.RegisterCompany
             Field<StringGraphType>("description");
             ExtendableField<MemberAddressType>("address",
                 resolve: context => (context.Source).Addresses?.FirstOrDefault(),
-                description: "Returns first organization address.",
-                deprecationReason: "Use addresses field instead.");
+                description: "Returns first organization address.");
             ExtendableField<ListGraphType<MemberAddressType>>("addresses",
                 resolve: context => (context.Source).Addresses,
                 description: "Organization's addresses");

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Schemas/RegisterCompany/RegisterOrganizationType.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Schemas/RegisterCompany/RegisterOrganizationType.cs
@@ -15,7 +15,13 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Schemas.RegisterCompany
             Field<NonNullGraphType<StringGraphType>>("id");
             Field<NonNullGraphType<StringGraphType>>("name");
             Field<StringGraphType>("description");
-            ExtendableField<MemberAddressType>("address", resolve: context => (context.Source).Addresses?.FirstOrDefault());
+            ExtendableField<MemberAddressType>("address",
+                resolve: context => (context.Source).Addresses?.FirstOrDefault(),
+                description: "Returns first organization address.",
+                deprecationReason: "Use addresses field instead.");
+            ExtendableField<ListGraphType<MemberAddressType>>("addresses",
+                resolve: context => (context.Source).Addresses,
+                description: "Organization addresses");
             Field<StringGraphType>("phoneNumber").Resolve(context => (context.Source).Phones?.FirstOrDefault());
             Field<StringGraphType>("status");
             Field<StringGraphType>("createdBy");

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Schemas/RegisterCompany/RegisterOrganizationType.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Schemas/RegisterCompany/RegisterOrganizationType.cs
@@ -21,14 +21,14 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Schemas.RegisterCompany
                 deprecationReason: "Use addresses field instead.");
             ExtendableField<ListGraphType<MemberAddressType>>("addresses",
                 resolve: context => (context.Source).Addresses,
-                description: "Organization addresses");
+                description: "Organization's addresses");
             Field<StringGraphType>("phoneNumber").Resolve(context => (context.Source).Phones?.FirstOrDefault());
             Field<StringGraphType>("status");
             Field<StringGraphType>("createdBy");
             Field<StringGraphType>("ownerId");
             ExtendableFieldAsync<ListGraphType<DynamicPropertyValueType>>(
                 "dynamicProperties",
-                "Contact's dynamic property values",
+                "Organization's dynamic property values",
                 QueryArgumentPresets.GetArgumentForDynamicProperties(),
                 async context => await dynamicPropertyResolverService.LoadDynamicPropertyValues(context.Source, context.GetArgumentOrValue<string>("cultureName")));
         }


### PR DESCRIPTION
## Description

1. Added `addresses` field to `requestRegistration` mutation
2. `address` field marked as deprecated
3. If both `addresses` and `address` are present in the mutation arguments they will be concatenated

```graphql
mutation {
  requestRegistration(command: {
    storeId: "B2B-store"
    languageCode: "en-US"
    organization: {
      name: "New organization"
      description: "My new organization"
      phoneNumber: "123456789"
      addresses: [{
        city: "qwe"
        countryCode: "ALA"
        countryName: "Åland Islands"
        description: "qwe"
        line1: "qwe line 1"
        postalCode: "1234567"
      }]
    }
    contact: {
      firstName: "John"
      lastName: "Doe"
      }
    account: {
      username: "john_doe"
      password: "test@test"
      email: "test@test"
    }
  }) {
    organization {
      id
      description
      phoneNumber
    }
  }
}
```
## References
### QA-test:
### Jira-link:




https://virtocommerce.atlassian.net/browse/VCST-3175
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.ProfileExperienceApiModule_3.914.0-pr-110-8c5f.zip