### PR TITLE
VCST-3647: Add account lockout check in ChangePasswordCommandHandler

### DIFF
--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/ChangePasswordCommandHandler.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/ChangePasswordCommandHandler.cs
@@ -57,6 +57,11 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
             else
             {
                 await userManager.AccessFailedAsync(user);
+
+                if (await userManager.IsLockedOutAsync(user))
+                {
+                    return CreateResponse(IdentityResult.Failed(new IdentityError { Code = "AccountLocked", Description = "Your account was locked." }));
+                }
             }
 
             return CreateResponse(result);

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/ChangePasswordCommandHandler.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/ChangePasswordCommandHandler.cs
@@ -41,12 +41,22 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
                 return CreateResponse(IdentityResult.Failed(new IdentityError { Code = "SamePassword", Description = "New password is the same as old password. Please choose another one." }));
             }
 
+            if (await userManager.IsLockedOutAsync(user))
+            {
+                return CreateResponse(IdentityResult.Failed(new IdentityError { Code = "AccountLocked", Description = "Your account is locked." }));
+            }
+
             var result = await userManager.ChangePasswordAsync(user, request.OldPassword, request.NewPassword);
 
             if (result.Succeeded && user.PasswordExpired)
             {
                 user.PasswordExpired = false;
                 await userManager.UpdateAsync(user);
+                await userManager.ResetAccessFailedCountAsync(user);
+            }
+            else
+            {
+                await userManager.AccessFailedAsync(user);
             }
 
             return CreateResponse(result);


### PR DESCRIPTION
## Description
Introduce a check for locked-out user accounts in the ChangePasswordCommand. If a user is locked out due to multiple failed login or password change attempts, an error result is returned with an error message.

## References
### QA-test:
### Jira-link:


https://virtocommerce.atlassian.net/browse/VCST-3647
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.ProfileExperienceApiModule_3.919.0-pr-116-ea4e.zip