### PR TITLE
VCST-3622: Reset password email should use correct store sender and template.

### DIFF
--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Queries/RequestPasswordResetQuery.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Queries/RequestPasswordResetQuery.cs
@@ -4,8 +4,11 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Queries
 {
     public class RequestPasswordResetQuery : IQuery<bool>
     {
+        public string StoreId { get; set; }
+        public string LanguageCode { get; set; }
         public string LoginOrEmail { get; set; }
 
         public string UrlSuffix { get; set; }
+
     }
 }

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Queries/RequestPasswordResetQuery.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Queries/RequestPasswordResetQuery.cs
@@ -5,10 +5,9 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Queries
     public class RequestPasswordResetQuery : IQuery<bool>
     {
         public string StoreId { get; set; }
-        public string LanguageCode { get; set; }
+        public string CultureName { get; set; }
         public string LoginOrEmail { get; set; }
 
         public string UrlSuffix { get; set; }
-
     }
 }

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Queries/RequestPasswordResetQueryHandler.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Queries/RequestPasswordResetQueryHandler.cs
@@ -70,7 +70,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Queries
             notification.Url = $"{store.Url.TrimLastSlash()}{request.UrlSuffix.NormalizeUrlSuffix()}?userId={user.Id}&token={Uri.EscapeDataString(token)}";
             notification.To = user.Email;
             notification.From = store.Email;
-            notification.LanguageCode = request.LanguageCode ?? store.DefaultLanguage;
+            notification.LanguageCode = request.CultureName ?? store.DefaultLanguage;
 
             await _notificationSender.ScheduleSendNotificationAsync(notification);
 

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Schemas/ProfileSchema.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Schemas/ProfileSchema.cs
@@ -222,7 +222,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Schemas
                     var result = await _mediator.Send(new RequestPasswordResetQuery
                     {
                         StoreId = context.GetArgument<string>("storeId"),
-                        LanguageCode = context.GetArgument<string>("languageCode"),
+                        CultureName = context.GetArgument<string>("cultureName"),
                         LoginOrEmail = context.GetArgument<string>("loginOrEmail"),
                         UrlSuffix = context.GetArgument<string>("urlSuffix"),
                     });

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Schemas/ProfileSchema.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Schemas/ProfileSchema.cs
@@ -212,6 +212,8 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Schemas
             {
                 Name = "requestPasswordReset",
                 Arguments = new QueryArguments(
+                    new QueryArgument<StringGraphType> { Name = "storeId" },
+                    new QueryArgument<StringGraphType> { Name = "languageCode" },
                     new QueryArgument<NonNullGraphType<StringGraphType>> { Name = "loginOrEmail" },
                     new QueryArgument<StringGraphType> { Name = "urlSuffix" }),
                 Type = GraphTypeExtensionHelper.GetActualType<BooleanGraphType>(),
@@ -219,6 +221,8 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Schemas
                 {
                     var result = await _mediator.Send(new RequestPasswordResetQuery
                     {
+                        StoreId = context.GetArgument<string>("storeId"),
+                        LanguageCode = context.GetArgument<string>("languageCode"),
                         LoginOrEmail = context.GetArgument<string>("loginOrEmail"),
                         UrlSuffix = context.GetArgument<string>("urlSuffix"),
                     });

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Schemas/ProfileSchema.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Schemas/ProfileSchema.cs
@@ -213,7 +213,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Schemas
                 Name = "requestPasswordReset",
                 Arguments = new QueryArguments(
                     new QueryArgument<StringGraphType> { Name = "storeId" },
-                    new QueryArgument<StringGraphType> { Name = "languageCode" },
+                    new QueryArgument<StringGraphType> { Name = "cultureName" },
                     new QueryArgument<NonNullGraphType<StringGraphType>> { Name = "loginOrEmail" },
                     new QueryArgument<StringGraphType> { Name = "urlSuffix" }),
                 Type = GraphTypeExtensionHelper.GetActualType<BooleanGraphType>(),


### PR DESCRIPTION
## Description
fix: Reset password email should use the correct store sender and template by adding StoreId and LanguageCode to the password reset query, the frontend should pass them for correct notification template resolving.

```graphql
query requestPasswordReset($storeId: String, $cultureName:String, $loginOrEmail: String!, $urlSuffix: String!) {
  requestPasswordReset(
    storeId: $storeId, 
    cultureName: $cultureName,
    loginOrEmail: $loginOrEmail, 
    urlSuffix: $urlSuffix)
}

{
  "loginOrEmail": "b2badmin@test.com",
  "urlSuffix": "/reset-password",
  "storeId": "B2B-store",
  "cultureName":"en-US"
}
```

## References
### QA-test:
### Jira-link:



https://virtocommerce.atlassian.net/browse/VCST-3622
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.ProfileExperienceApiModule_3.919.0-pr-117-1329.zip