### PR TITLE
VCST-4803: Improve NewContactValidator

### DIFF
--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Validators/NewContactValidator.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Validators/NewContactValidator.cs
@@ -16,10 +16,17 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Validators
             RuleFor(x => x.FirstName).NotNull().NotEmpty().MaximumLength(128);
             RuleFor(x => x.LastName).NotNull().NotEmpty().MaximumLength(128);
 
+            RuleForEach(x => x.Phones).MaximumLength(64);
+
             When(_ => hasNamePattern, () =>
             {
                 RuleFor(x => x.FirstName).MatchesNamePattern(options.NameValidationPattern);
                 RuleFor(x => x.LastName).MatchesNamePattern(options.NameValidationPattern);
+            });
+
+            When(_ => options.EnableNoHtmlTagsValidation, () =>
+            {
+                RuleForEach(x => x.Phones).NoHtmlTags();
             });
 
             RuleSet("strict", () =>


### PR DESCRIPTION
## Description
fix: Improve NewContactValidator for Phones

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-4803
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.ProfileExperienceApiModule_3.1004.0-pr-132-79c7.zip
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds additional input validation on `Contact.Phones`, which may cause some previously accepted phone values to be rejected but does not change core business logic.
> 
> **Overview**
> Improves `NewContactValidator` by validating each entry in `Contact.Phones`: enforcing a max length of 64 and (when `EnableNoHtmlTagsValidation` is enabled) rejecting HTML tags via `NoHtmlTags()`.
> 
> Name pattern checks and the existing `strict` ruleset are unchanged; this PR primarily tightens phone input sanitization/constraints.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 79c799c9e6b63df89d220654ecb775a471a69eac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->