### PR TITLE
VCST-4576: Terminate sessions after password change

### DIFF
--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/ChangePasswordCommand.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/ChangePasswordCommand.cs
@@ -1,5 +1,5 @@
-using VirtoCommerce.Xapi.Core.Infrastructure;
 using VirtoCommerce.ProfileExperienceApiModule.Data.Queries;
+using VirtoCommerce.Xapi.Core.Infrastructure;
 
 namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
 {
@@ -10,5 +10,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
         public string OldPassword { get; set; }
 
         public string NewPassword { get; set; }
+
+        public string SessionGroupId { get; set; }
     }
 }

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/ChangePasswordCommandHandler.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/ChangePasswordCommandHandler.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using MediatR;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Platform.Core.Security;
@@ -17,14 +18,17 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
     public class ChangePasswordCommandHandler : UserCommandHandlerBase, IRequestHandler<ChangePasswordCommand, IdentityResultResponse>
     {
         private readonly Func<(IUserSessionsService SessionService, IServiceScope Scope)> _userSessionsServiceFactory;
+        private readonly ILogger<ChangePasswordCommandHandler> _logger;
 
         public ChangePasswordCommandHandler(
             Func<UserManager<ApplicationUser>> userManagerFactory,
             IOptions<AuthorizationOptions> securityOptions,
-            Func<(IUserSessionsService SessionService, IServiceScope Scope)> userSessionsServiceFactory)
+            Func<(IUserSessionsService SessionService, IServiceScope Scope)> userSessionsServiceFactory,
+            ILogger<ChangePasswordCommandHandler> logger)
             : base(userManagerFactory, securityOptions)
         {
             _userSessionsServiceFactory = userSessionsServiceFactory;
+            _logger = logger;
         }
 
         public async Task<IdentityResultResponse> Handle(ChangePasswordCommand request, CancellationToken cancellationToken)
@@ -90,20 +94,27 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
 
         private async Task TryTerminateUserSessions(ChangePasswordCommand command)
         {
-            var (SessionService, Scope) = _userSessionsServiceFactory();
-            using var scope = Scope;
-
-            var terminateSessionsRequest = new TerminateUserSessionsRequest
+            try
             {
-                UserId = command.UserId,
-            };
+                var (SessionService, Scope) = _userSessionsServiceFactory();
+                using var scope = Scope;
 
-            if (!command.SessionGroupId.IsNullOrEmpty())
-            {
-                terminateSessionsRequest.ExcludedSessionGroupIds = [command.SessionGroupId];
+                var terminateSessionsRequest = new TerminateUserSessionsRequest
+                {
+                    UserId = command.UserId,
+                };
+
+                if (!command.SessionGroupId.IsNullOrEmpty())
+                {
+                    terminateSessionsRequest.ExcludedSessionGroupIds = [command.SessionGroupId];
+                }
+
+                await SessionService.TerminateUserSessions(terminateSessionsRequest);
             }
-
-            await SessionService.TerminateUserSessions(terminateSessionsRequest);
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to terminate sessions for user {userId} after password change", command.UserId);
+            }
         }
     }
 }

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/ChangePasswordCommandHandler.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/ChangePasswordCommandHandler.cs
@@ -4,7 +4,9 @@ using System.Threading;
 using System.Threading.Tasks;
 using MediatR;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Platform.Core.Security;
 using VirtoCommerce.ProfileExperienceApiModule.Data.Extensions;
 using VirtoCommerce.ProfileExperienceApiModule.Data.Queries;
@@ -14,11 +16,15 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
 {
     public class ChangePasswordCommandHandler : UserCommandHandlerBase, IRequestHandler<ChangePasswordCommand, IdentityResultResponse>
     {
+        private readonly Func<(IUserSessionsService SessionService, IServiceScope Scope)> _userSessionsServiceFactory;
+
         public ChangePasswordCommandHandler(
             Func<UserManager<ApplicationUser>> userManagerFactory,
-            IOptions<AuthorizationOptions> securityOptions)
+            IOptions<AuthorizationOptions> securityOptions,
+            Func<(IUserSessionsService SessionService, IServiceScope Scope)> userSessionsServiceFactory)
             : base(userManagerFactory, securityOptions)
         {
+            _userSessionsServiceFactory = userSessionsServiceFactory;
         }
 
         public async Task<IdentityResultResponse> Handle(ChangePasswordCommand request, CancellationToken cancellationToken)
@@ -65,6 +71,11 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
                 }
             }
 
+            if (result.Succeeded)
+            {
+                await TryTerminateUserSessions(request);
+            }
+
             return CreateResponse(result);
         }
 
@@ -75,6 +86,24 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
                 Errors = identityResult?.Errors.Select(x => x.MapToIdentityErrorInfo()).ToList(),
                 Succeeded = identityResult?.Succeeded ?? false
             };
+        }
+
+        private async Task TryTerminateUserSessions(ChangePasswordCommand command)
+        {
+            var (SessionService, Scope) = _userSessionsServiceFactory();
+            using var scope = Scope;
+
+            var terminateSessionsRequest = new TerminateUserSessionsRequest
+            {
+                UserId = command.UserId,
+            };
+
+            if (!command.SessionGroupId.IsNullOrEmpty())
+            {
+                terminateSessionsRequest.ExcludedSessionGroupIds = [command.SessionGroupId];
+            }
+
+            await SessionService.TerminateUserSessions(terminateSessionsRequest);
         }
     }
 }

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/ResetPasswordByTokenCommandHandler.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/ResetPasswordByTokenCommandHandler.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using MediatR;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using VirtoCommerce.Platform.Core.Security;
 using VirtoCommerce.ProfileExperienceApiModule.Data.Extensions;
@@ -15,14 +16,17 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
     public class ResetPasswordByTokenCommandHandler : UserCommandHandlerBase, IRequestHandler<ResetPasswordByTokenCommand, IdentityResultResponse>
     {
         private readonly Func<(IUserSessionsService SessionService, IServiceScope Scope)> _userSessionsServiceFactory;
+        private readonly ILogger<ResetPasswordByTokenCommandHandler> _logger;
 
         public ResetPasswordByTokenCommandHandler(
             Func<UserManager<ApplicationUser>> userManagerFactory,
             IOptions<AuthorizationOptions> securityOptions,
-            Func<(IUserSessionsService SessionService, IServiceScope Scope)> userSessionsServiceFactory)
+            Func<(IUserSessionsService SessionService, IServiceScope Scope)> userSessionsServiceFactory,
+            ILogger<ResetPasswordByTokenCommandHandler> logger)
             : base(userManagerFactory, securityOptions)
         {
             _userSessionsServiceFactory = userSessionsServiceFactory;
+            _logger = logger;
         }
 
         public virtual async Task<IdentityResultResponse> Handle(ResetPasswordByTokenCommand request, CancellationToken cancellationToken)
@@ -57,8 +61,8 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
 
                 if (identityResult.Succeeded)
                 {
-                    // terminate all sessions for password reset request
-                    await TerminateAllUserSessions(user.Id);
+                    // terminate all user's sessions for password reset request
+                    await TryTerminateAllUserSessions(user.Id);
                 }
             }
 
@@ -68,11 +72,18 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
             return result;
         }
 
-        private async Task TerminateAllUserSessions(string userId)
+        private async Task TryTerminateAllUserSessions(string userId)
         {
-            var (SessionService, Scope) = _userSessionsServiceFactory();
-            using var scope = Scope;
-            await SessionService.TerminateAllUserSessions(userId);
+            try
+            {
+                var (SessionService, Scope) = _userSessionsServiceFactory();
+                using var scope = Scope;
+                await SessionService.TerminateAllUserSessions(userId);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to terminate sessions for user {userId} after password reset", userId);
+            }
         }
     }
 }

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/ResetPasswordByTokenCommandHandler.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/ResetPasswordByTokenCommandHandler.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using MediatR;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using VirtoCommerce.Platform.Core.Security;
 using VirtoCommerce.ProfileExperienceApiModule.Data.Extensions;
@@ -13,11 +14,15 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
 {
     public class ResetPasswordByTokenCommandHandler : UserCommandHandlerBase, IRequestHandler<ResetPasswordByTokenCommand, IdentityResultResponse>
     {
+        private readonly Func<(IUserSessionsService SessionService, IServiceScope Scope)> _userSessionsServiceFactory;
+
         public ResetPasswordByTokenCommandHandler(
             Func<UserManager<ApplicationUser>> userManagerFactory,
-            IOptions<AuthorizationOptions> securityOptions)
+            IOptions<AuthorizationOptions> securityOptions,
+            Func<(IUserSessionsService SessionService, IServiceScope Scope)> userSessionsServiceFactory)
             : base(userManagerFactory, securityOptions)
         {
+            _userSessionsServiceFactory = userSessionsServiceFactory;
         }
 
         public virtual async Task<IdentityResultResponse> Handle(ResetPasswordByTokenCommand request, CancellationToken cancellationToken)
@@ -49,12 +54,25 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
                     user.PasswordExpired = false;
                     await userManager.UpdateAsync(user);
                 }
+
+                if (identityResult.Succeeded)
+                {
+                    // terminate all sessions for password reset request
+                    await TerminateAllUserSessions(user.Id);
+                }
             }
 
             result.Errors = identityResult?.Errors.Select(x => x.MapToIdentityErrorInfo()).ToList();
             result.Succeeded = identityResult?.Succeeded ?? false;
 
             return result;
+        }
+
+        private async Task TerminateAllUserSessions(string userId)
+        {
+            var (SessionService, Scope) = _userSessionsServiceFactory();
+            using var scope = Scope;
+            await SessionService.TerminateAllUserSessions(userId);
         }
     }
 }

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Schemas/ProfileSchema.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Schemas/ProfileSchema.cs
@@ -10,6 +10,7 @@ using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Logging;
+using OpenIddict.Abstractions;
 using VirtoCommerce.CoreModule.Core.Common;
 using VirtoCommerce.Platform.Core.Security;
 using VirtoCommerce.Platform.Security.Authorization;
@@ -465,6 +466,8 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Schemas
                             var type = GenericTypeHelper.GetActualType<ChangePasswordCommand>();
                             var command = (ChangePasswordCommand)context.GetArgument(type, _commandName);
                             await CheckAuthAsync(context, command, checkPasswordExpired: false);
+
+                            command.SessionGroupId = context.User.FindFirstValue(OpenIddictConstants.Claims.Private.AuthorizationId);
 
                             return await _mediator.Send(command);
                         })

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/VirtoCommerce.ProfileExperienceApiModule.Data.csproj
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/VirtoCommerce.ProfileExperienceApiModule.Data.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="VirtoCommerce.CustomerModule.Core" Version="3.1000.0" />
     <PackageReference Include="VirtoCommerce.MarketingModule.Core" Version="3.1000.0" />
     <PackageReference Include="VirtoCommerce.NotificationsModule.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.1020.1" />
+    <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.1022.0-alpha.13258-vcst-4576" />
     <PackageReference Include="VirtoCommerce.PricingModule.Core" Version="3.1000.0" />
     <PackageReference Include="VirtoCommerce.TaxModule.Core" Version="3.1000.0" />
     <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.1000.0" />

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/VirtoCommerce.ProfileExperienceApiModule.Data.csproj
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/VirtoCommerce.ProfileExperienceApiModule.Data.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="VirtoCommerce.CustomerModule.Core" Version="3.1000.0" />
     <PackageReference Include="VirtoCommerce.MarketingModule.Core" Version="3.1000.0" />
     <PackageReference Include="VirtoCommerce.NotificationsModule.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.1002.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.1020.1" />
     <PackageReference Include="VirtoCommerce.PricingModule.Core" Version="3.1000.0" />
     <PackageReference Include="VirtoCommerce.TaxModule.Core" Version="3.1000.0" />
     <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.1000.0" />

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/VirtoCommerce.ProfileExperienceApiModule.Data.csproj
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/VirtoCommerce.ProfileExperienceApiModule.Data.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="VirtoCommerce.CustomerModule.Core" Version="3.1007.0" />
     <PackageReference Include="VirtoCommerce.MarketingModule.Core" Version="3.1000.0" />
     <PackageReference Include="VirtoCommerce.NotificationsModule.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.1026.0-alpha.13278-vcst-4576" />
+    <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.1027.0-alpha.13286-vcst-4576" />
     <PackageReference Include="VirtoCommerce.PricingModule.Core" Version="3.1000.0" />
     <PackageReference Include="VirtoCommerce.TaxModule.Core" Version="3.1000.0" />
     <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.1000.0" />

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/VirtoCommerce.ProfileExperienceApiModule.Data.csproj
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/VirtoCommerce.ProfileExperienceApiModule.Data.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="VirtoCommerce.CustomerModule.Core" Version="3.1007.0" />
     <PackageReference Include="VirtoCommerce.MarketingModule.Core" Version="3.1000.0" />
     <PackageReference Include="VirtoCommerce.NotificationsModule.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.1027.0-alpha.13286-vcst-4576" />
+    <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.1027.0" />
     <PackageReference Include="VirtoCommerce.PricingModule.Core" Version="3.1000.0" />
     <PackageReference Include="VirtoCommerce.TaxModule.Core" Version="3.1000.0" />
     <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.1000.0" />

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Web/module.manifest
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Web/module.manifest
@@ -4,7 +4,7 @@
   <version>3.1005.0</version>
   <version-tag />
 
-  <platformVersion>3.1020.1</platformVersion>
+  <platformVersion>3.1022.0-alpha.13258-vcst-4576</platformVersion>
   <dependencies>
     <dependency id="VirtoCommerce.Customer" version="3.1000.0" />
     <dependency id="VirtoCommerce.Marketing" version="3.1000.0" optional="true" />

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Web/module.manifest
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Web/module.manifest
@@ -4,7 +4,7 @@
   <version>3.1006.0</version>
   <version-tag />
 
-  <platformVersion>3.1027.0-alpha.13286-vcst-4576</platformVersion>
+  <platformVersion>3.1027.0</platformVersion>
   <dependencies>
     <dependency id="VirtoCommerce.Customer" version="3.1007.0" />
     <dependency id="VirtoCommerce.Marketing" version="3.1000.0" optional="true" />

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Web/module.manifest
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Web/module.manifest
@@ -4,7 +4,7 @@
   <version>3.1005.0</version>
   <version-tag />
 
-  <platformVersion>3.1002.0</platformVersion>
+  <platformVersion>3.1020.1</platformVersion>
   <dependencies>
     <dependency id="VirtoCommerce.Customer" version="3.1000.0" />
     <dependency id="VirtoCommerce.Marketing" version="3.1000.0" optional="true" />

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Web/module.manifest
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Web/module.manifest
@@ -4,7 +4,7 @@
   <version>3.1006.0</version>
   <version-tag />
 
-  <platformVersion>3.1026.0-alpha.13278-vcst-4576</platformVersion>
+  <platformVersion>3.1027.0-alpha.13286-vcst-4576</platformVersion>
   <dependencies>
     <dependency id="VirtoCommerce.Customer" version="3.1007.0" />
     <dependency id="VirtoCommerce.Marketing" version="3.1000.0" optional="true" />


### PR DESCRIPTION
## Description
Reset Password by token - terminate all sessions.
Change Password - terminate sessions except the current one.
## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-4576
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.ProfileExperienceApiModule_3.1007.0-pr-133-d707.zip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication/session-management flow by terminating sessions after password updates, which could inadvertently log out users or miss exclusions if session identifiers are wrong.
> 
> **Overview**
> **For password changes and resets, sessions are now invalidated.** After a successful `changePassword`, the handler terminates all user sessions *except* the current one (excluded via a new `SessionGroupId` captured from the OpenIddict `AuthorizationId` claim). After a successful `resetPasswordByToken`, the handler terminates *all* of the user’s sessions.
> 
> This introduces session-termination calls via `IUserSessionsService` (with error-logged best-effort behavior) and bumps `VirtoCommerce.Platform.Security`/`platformVersion` from `3.1025.0` to `3.1027.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7070bc75419f28208fba0a6ebdca47c9cd9e615. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->