### PR TITLE
VCST-5073: Add address search by id

### DIFF
--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Models/MemberAddressSearchCriteria.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Models/MemberAddressSearchCriteria.cs
@@ -5,6 +5,8 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Models;
 
 public class MemberAddressSearchCriteria : SearchCriteriaBase
 {
+    public IList<string> Ids { get; set; }
+
     public string MemberId { get; set; }
 
     public string UserId { get; set; }

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Queries/AddressesQuery/BaseAddressesQuery.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Queries/AddressesQuery/BaseAddressesQuery.cs
@@ -17,6 +17,7 @@ public abstract class BaseAddressesQuery : SearchQuery<MemberAddressSearchResult
 
     public IList<string> Cities { get; set; }
 
+    public IList<string> Ids { get; set; }
 
     public override IEnumerable<QueryArgument> GetArguments()
     {
@@ -28,6 +29,7 @@ public abstract class BaseAddressesQuery : SearchQuery<MemberAddressSearchResult
         yield return Argument<ListGraphType<StringGraphType>>(nameof(CountryCodes));
         yield return Argument<ListGraphType<StringGraphType>>(nameof(RegionIds));
         yield return Argument<ListGraphType<StringGraphType>>(nameof(Cities));
+        yield return Argument<ListGraphType<StringGraphType>>(nameof(Ids));
     }
 
     public override void Map(IResolveFieldContext context)
@@ -37,6 +39,7 @@ public abstract class BaseAddressesQuery : SearchQuery<MemberAddressSearchResult
         CountryCodes = context.GetArgument<List<string>>(nameof(CountryCodes));
         RegionIds = context.GetArgument<List<string>>(nameof(RegionIds));
         Cities = context.GetArgument<List<string>>(nameof(Cities));
+        Ids = context.GetArgument<List<string>>(nameof(Ids));
 
         UserId = context.GetCurrentUserId();
     }

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Queries/AddressesQuery/BaseAddressesQueryHandler.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Queries/AddressesQuery/BaseAddressesQueryHandler.cs
@@ -29,6 +29,7 @@ public abstract class BaseAddressesQueryHandler
     {
         var addressSearchCriteria = AbstractTypeFactory<MemberAddressSearchCriteria>.TryCreateInstance();
 
+        addressSearchCriteria.Ids = criteria.Ids;
         addressSearchCriteria.UserId = criteria.UserId;
         addressSearchCriteria.MemberId = memberId;
 

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Services/MemberAddressService.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Services/MemberAddressService.cs
@@ -130,6 +130,7 @@ public class MemberAddressService : IMemberAddressService
     {
         var addressSearchCriteria = AbstractTypeFactory<AddressSearchCriteria>.TryCreateInstance();
 
+        addressSearchCriteria.ObjectIds = criteria.Ids;
         addressSearchCriteria.MemberId = criteria.MemberId;
         addressSearchCriteria.UserId = criteria.UserId;
         addressSearchCriteria.Take = criteria.Take;


### PR DESCRIPTION
## Description
feat: Add address search by id for currentOrganizationAddresses and currentCustomerAddresses queries

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5073
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.ProfileExperienceApiModule_3.1006.0-pr-134-3740.zip
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds an optional `Ids` filter plumbed through the GraphQL query layer into existing address search criteria, with no changes to auth or mutation logic.
> 
> **Overview**
> Adds an optional `Ids` argument to the base GraphQL addresses queries and threads it through `BaseAddressesQueryHandler` into `MemberAddressService`.
> 
> The service now maps `MemberAddressSearchCriteria.Ids` to the underlying `AddressSearchCriteria.ObjectIds`, enabling address lookup/filtering by specific IDs alongside existing country/region/city filters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37402b7e8c50020521133c59115a8b61c91ad046. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->