### PR TITLE
VCST-5163: Stable 15 — ProfileExperienceApi (platform 3.1039.0)

### DIFF
--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/VirtoCommerce.ProfileExperienceApiModule.Data.csproj
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/VirtoCommerce.ProfileExperienceApiModule.Data.csproj
@@ -7,13 +7,13 @@
     <SonarQubeTestProject>false</SonarQubeTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="VirtoCommerce.CustomerModule.Core" Version="3.1010.0" />
-    <PackageReference Include="VirtoCommerce.MarketingModule.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.NotificationsModule.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.1027.0" />
-    <PackageReference Include="VirtoCommerce.PricingModule.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.TaxModule.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.XOrder.Core" Version="3.1000.0" />
+    <PackageReference Include="VirtoCommerce.CustomerModule.Core" Version="3.1011.0" />
+    <PackageReference Include="VirtoCommerce.MarketingModule.Core" Version="3.1005.0" />
+    <PackageReference Include="VirtoCommerce.NotificationsModule.Core" Version="3.1009.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.1039.0" />
+    <PackageReference Include="VirtoCommerce.PricingModule.Core" Version="3.1003.0" />
+    <PackageReference Include="VirtoCommerce.TaxModule.Core" Version="3.1003.0" />
+    <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.1012.0" />
+    <PackageReference Include="VirtoCommerce.XOrder.Core" Version="3.1005.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Web/module.manifest
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Web/module.manifest
@@ -4,15 +4,15 @@
   <version>3.1009.0</version>
   <version-tag />
 
-  <platformVersion>3.1027.0</platformVersion>
+  <platformVersion>3.1039.0</platformVersion>
   <dependencies>
-    <dependency id="VirtoCommerce.Customer" version="3.1010.0" />
-    <dependency id="VirtoCommerce.Marketing" version="3.1000.0" optional="true" />
-    <dependency id="VirtoCommerce.Notifications" version="3.1000.0" />
-    <dependency id="VirtoCommerce.Pricing" version="3.1000.0" optional="true" />
-    <dependency id="VirtoCommerce.Tax" version="3.1000.0" optional="true" />
-    <dependency id="VirtoCommerce.Xapi" version="3.1000.0" />
-    <dependency id="VirtoCommerce.XOrder" version="3.1000.0" optional="true" />
+    <dependency id="VirtoCommerce.Customer" version="3.1011.0" />
+    <dependency id="VirtoCommerce.Marketing" version="3.1005.0" optional="true" />
+    <dependency id="VirtoCommerce.Notifications" version="3.1009.0" />
+    <dependency id="VirtoCommerce.Pricing" version="3.1003.0" optional="true" />
+    <dependency id="VirtoCommerce.Tax" version="3.1003.0" optional="true" />
+    <dependency id="VirtoCommerce.Xapi" version="3.1012.0" />
+    <dependency id="VirtoCommerce.XOrder" version="3.1005.0" optional="true" />
   </dependencies>
 
   <title>Commerce Profile Experience API</title>


### PR DESCRIPTION
Part of **Stable 15** (Wave 11). Actualized from dev, then bumped platform [3.1039.0](https://github.com/VirtoCommerce/vc-platform/releases/tag/3.1039.0) + inter-module deps to released Stable-15 versions (Customer 3.1011.0, Marketing 3.1005.0, Notifications 3.1009.0, Pricing 3.1003.0, Tax 3.1003.0, Xapi 3.1012.0, XOrder 3.1005.0). Version handled by CI.

- `vc-build Compress` green incl. unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only dependency alignment with no logic changes; main risk is compatibility with the wider Stable 15 stack at deploy time.
> 
> **Overview**
> Aligns **ProfileExperienceApi** with **Stable 15** by raising the platform requirement and all related package/manifest dependency versions—no application code changes.
> 
> **`module.manifest`** sets `platformVersion` to **3.1039.0** and updates module dependencies (Customer **3.1011.0**, Marketing **3.1005.0**, Notifications **3.1009.0**, Pricing/Tax **3.1003.0**, Xapi **3.1012.0**, XOrder **3.1005.0**). **`VirtoCommerce.ProfileExperienceApiModule.Data.csproj`** bumps the matching `VirtoCommerce.*Module.Core` / `Platform.Security` NuGet references to the same released versions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 906c19ef59edbe4d614e64ba75009c4349b9f340. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5163
Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.ProfileExperienceApiModule_3.1009.0-pr-136-906c.zip