### PR TITLE
VCST-5435: Make ChangeOrganizationContactRoleCommandHandler extendable

### DIFF
--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/ChangeOrganizationContactRoleCommandHandler.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/ChangeOrganizationContactRoleCommandHandler.cs
@@ -34,11 +34,11 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
             _contactAggregateRepository = contactAggregateRepository;
         }
 
-        public async Task<IdentityResultResponse> Handle(ChangeOrganizationContactRoleCommand request, CancellationToken cancellationToken)
+        public virtual async Task<IdentityResultResponse> Handle(ChangeOrganizationContactRoleCommand request, CancellationToken cancellationToken)
         {
             var result = new IdentityResultResponse
             {
-                Errors = new List<IdentityErrorInfo>(),
+                Errors = [],
                 Succeeded = false,
             };
 
@@ -48,27 +48,72 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
                 return result;
             }
 
-            var contactAggregate = await _contactAggregateRepository.GetMemberAggregateRootByIdAsync<ContactAggregate>(request.MemberId)
+            var contactAggregate = await GetContactAggregateAsync(request.MemberId)
                 ?? throw new InvalidOperationException($"Contact '{request.MemberId}' not found.");
 
-            var userId = contactAggregate.Contact?.SecurityAccounts?.FirstOrDefault()?.Id;
+            var userId = GetSecurityAccountId(contactAggregate);
             if (string.IsNullOrEmpty(userId))
             {
                 result.Errors.Add(new IdentityErrorInfo { Code = "Forbidden", Description = "It is forbidden to edit this user." });
                 return result;
             }
 
+            if (!await ValidateUserEditableAsync(userId, result))
+            {
+                return result;
+            }
+
+            var roles = await ResolveRolesAsync(request.RoleIds, result);
+            if (result.Errors.Count > 0)
+            {
+                return result;
+            }
+
+            var membership = await GetMembershipAsync(userId, request.OrganizationId);
+            if (membership == null)
+            {
+                result.Errors.Add(new IdentityErrorInfo
+                {
+                    Code = "MembershipNotFound",
+                    Description = $"Contact '{request.MemberId}' has no membership in organization '{request.OrganizationId}'.",
+                });
+                return result;
+            }
+
+            await ApplyRolesAsync(membership, roles, cancellationToken);
+
+            result.Succeeded = true;
+            return result;
+        }
+
+        protected virtual Task<ContactAggregate> GetContactAggregateAsync(string memberId)
+        {
+            return _contactAggregateRepository.GetMemberAggregateRootByIdAsync<ContactAggregate>(memberId);
+        }
+
+        protected virtual string GetSecurityAccountId(ContactAggregate contactAggregate)
+        {
+            return contactAggregate.Contact?.SecurityAccounts?.FirstOrDefault()?.Id;
+        }
+
+        protected virtual async Task<bool> ValidateUserEditableAsync(string userId, IdentityResultResponse result)
+        {
             using var userManager = _userManagerFactory();
             var user = await userManager.FindByIdAsync(userId);
             if (user == null || !IsUserEditable(user.UserName))
             {
                 result.Errors.Add(new IdentityErrorInfo { Code = "Forbidden", Description = "It is forbidden to edit this user." });
-                return result;
+                return false;
             }
 
+            return true;
+        }
+
+        protected virtual async Task<IList<Role>> ResolveRolesAsync(string[] roleIds, IdentityResultResponse result)
+        {
             using var roleManager = _roleManagerFactory();
             var roles = new List<Role>();
-            foreach (var roleId in request.RoleIds ?? [])
+            foreach (var roleId in roleIds ?? [])
             {
                 var role = await roleManager.FindByIdAsync(roleId) ?? await roleManager.FindByNameAsync(roleId);
                 if (role != null)
@@ -81,23 +126,17 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
                 }
             }
 
-            if (result.Errors.Count > 0)
-            {
-                return result;
-            }
+            return roles;
+        }
 
-            var membership = await _organizationMembershipService.GetByUserAndOrgAsync(userId, request.OrganizationId);
-            if (membership == null)
-            {
-                result.Errors.Add(new IdentityErrorInfo
-                {
-                    Code = "MembershipNotFound",
-                    Description = $"Contact '{request.MemberId}' has no membership in organization '{request.OrganizationId}'.",
-                });
-                return result;
-            }
+        protected virtual Task<OrganizationMembership> GetMembershipAsync(string userId, string organizationId)
+        {
+            return _organizationMembershipService.GetByUserAndOrgAsync(userId, organizationId);
+        }
 
-            membership.Roles = roles
+        protected virtual IList<OrganizationMembershipRole> BuildMembershipRoles(OrganizationMembership membership, IList<Role> roles)
+        {
+            return roles
                 .Select(r => new OrganizationMembershipRole
                 {
                     MembershipId = membership.Id,
@@ -105,11 +144,12 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
                     RoleName = r.Name,
                 })
                 .ToList();
+        }
 
+        protected virtual async Task ApplyRolesAsync(OrganizationMembership membership, IList<Role> roles, CancellationToken cancellationToken)
+        {
+            membership.Roles = BuildMembershipRoles(membership, roles);
             await _organizationMembershipService.SaveChangesAsync([membership]);
-
-            result.Succeeded = true;
-            return result;
         }
     }
 }

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/ChangeOrganizationContactRoleCommandHandler.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/ChangeOrganizationContactRoleCommandHandler.cs
@@ -48,7 +48,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
                 return result;
             }
 
-            var contactAggregate = await GetContactAggregateAsync(request.MemberId)
+            var contactAggregate = await GetContactAggregate(request.MemberId)
                 ?? throw new InvalidOperationException($"Contact '{request.MemberId}' not found.");
 
             var userId = GetSecurityAccountId(contactAggregate);
@@ -58,18 +58,18 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
                 return result;
             }
 
-            if (!await ValidateUserEditableAsync(userId, result))
+            if (!await ValidateUserEditable(userId, result))
             {
                 return result;
             }
 
-            var roles = await ResolveRolesAsync(request.RoleIds, result);
+            var roles = await ResolveRoles(request.RoleIds, result);
             if (result.Errors.Count > 0)
             {
                 return result;
             }
 
-            var membership = await GetMembershipAsync(userId, request.OrganizationId);
+            var membership = await GetMembership(userId, request.OrganizationId);
             if (membership == null)
             {
                 result.Errors.Add(new IdentityErrorInfo
@@ -80,13 +80,13 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
                 return result;
             }
 
-            await ApplyRolesAsync(membership, roles, cancellationToken);
+            await ApplyRoles(membership, roles, cancellationToken);
 
             result.Succeeded = true;
             return result;
         }
 
-        protected virtual Task<ContactAggregate> GetContactAggregateAsync(string memberId)
+        protected virtual Task<ContactAggregate> GetContactAggregate(string memberId)
         {
             return _contactAggregateRepository.GetMemberAggregateRootByIdAsync<ContactAggregate>(memberId);
         }
@@ -96,7 +96,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
             return contactAggregate.Contact?.SecurityAccounts?.FirstOrDefault()?.Id;
         }
 
-        protected virtual async Task<bool> ValidateUserEditableAsync(string userId, IdentityResultResponse result)
+        protected virtual async Task<bool> ValidateUserEditable(string userId, IdentityResultResponse result)
         {
             using var userManager = _userManagerFactory();
             var user = await userManager.FindByIdAsync(userId);
@@ -109,7 +109,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
             return true;
         }
 
-        protected virtual async Task<IList<Role>> ResolveRolesAsync(string[] roleIds, IdentityResultResponse result)
+        protected virtual async Task<IList<Role>> ResolveRoles(string[] roleIds, IdentityResultResponse result)
         {
             using var roleManager = _roleManagerFactory();
             var roles = new List<Role>();
@@ -129,7 +129,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
             return roles;
         }
 
-        protected virtual Task<OrganizationMembership> GetMembershipAsync(string userId, string organizationId)
+        protected virtual Task<OrganizationMembership> GetMembership(string userId, string organizationId)
         {
             return _organizationMembershipService.GetByUserAndOrgAsync(userId, organizationId);
         }
@@ -146,7 +146,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
                 .ToList();
         }
 
-        protected virtual async Task ApplyRolesAsync(OrganizationMembership membership, IList<Role> roles, CancellationToken cancellationToken)
+        protected virtual async Task ApplyRoles(OrganizationMembership membership, IList<Role> roles, CancellationToken cancellationToken)
         {
             membership.Roles = BuildMembershipRoles(membership, roles);
             await _organizationMembershipService.SaveChangesAsync([membership]);


### PR DESCRIPTION
## Description
fix: Make ChangeOrganizationContactRoleCommandHandler extendable

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5435
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.ProfileExperienceApiModule_3.1012.0-pr-138-116b.zip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authorization and organization membership role persistence; behavior should be unchanged but overrides could alter security-sensitive flows in custom handlers.
> 
> **Overview**
> Refactors **organization contact role assignment** so subclasses can override individual steps without duplicating the full `Handle` flow.
> 
> `Handle` is now **virtual** and orchestrates the same validation and persistence path through new **protected virtual** helpers: contact load, security account resolution, editability check, role resolution, membership lookup, role mapping (`BuildMembershipRoles`), and save (`ApplyRoles`). Error handling and success semantics stay in `Handle`; helpers return data or signal failures (e.g. `ValidateUserEditable` returns false after adding errors).
> 
> Minor cleanup: initializes `Errors` with a collection expression (`[]`) instead of `new List<IdentityErrorInfo>()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 116bf97cc9b66619d32cd9b645ce401e7afbea4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->