### PR TITLE
VCST-5468: Resolve mediators per request

### DIFF
--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/AddAddressToFavoritesCommandBuilder.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/AddAddressToFavoritesCommandBuilder.cs
@@ -1,11 +1,12 @@
+using System;
 using System.Threading.Tasks;
 using GraphQL;
 using GraphQL.Types;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
+using VirtoCommerce.ProfileExperienceApiModule.Data.Services;
 using VirtoCommerce.Xapi.Core.BaseQueries;
 using VirtoCommerce.Xapi.Core.Extensions;
-using VirtoCommerce.ProfileExperienceApiModule.Data.Services;
 
 namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands;
 
@@ -16,12 +17,17 @@ public class AddAddressToFavoritesCommandBuilder : CommandBuilder<AddAddressToFa
     private readonly IProfileAuthorizationService _profileAuthorizationService;
 
     public AddAddressToFavoritesCommandBuilder(
-        IMediator mediator,
         IAuthorizationService authorizationService,
         IProfileAuthorizationService profileAuthorizationService)
-        : base(mediator, authorizationService)
+        : base(authorizationService)
     {
         _profileAuthorizationService = profileAuthorizationService;
+    }
+
+    [Obsolete("Use the constructor without IMediator. The mediator is resolved from context.RequestServices per request.", DiagnosticId = "VC0015", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
+    public AddAddressToFavoritesCommandBuilder(IMediator mediator, IAuthorizationService authorizationService, IProfileAuthorizationService profileAuthorizationService)
+        : this(authorizationService, profileAuthorizationService)
+    {
     }
 
     protected override AddAddressToFavoritesCommand GetRequest(IResolveFieldContext<object> context)

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/RemoveAddressFromFavoritesCommandBuilder.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/RemoveAddressFromFavoritesCommandBuilder.cs
@@ -1,11 +1,12 @@
+using System;
 using System.Threading.Tasks;
 using GraphQL;
 using GraphQL.Types;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
+using VirtoCommerce.ProfileExperienceApiModule.Data.Services;
 using VirtoCommerce.Xapi.Core.BaseQueries;
 using VirtoCommerce.Xapi.Core.Extensions;
-using VirtoCommerce.ProfileExperienceApiModule.Data.Services;
 
 namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands;
 
@@ -16,12 +17,17 @@ public class RemoveAddressFromFavoritesCommandBuilder : CommandBuilder<RemoveAdd
     private readonly IProfileAuthorizationService _profileAuthorizationService;
 
     public RemoveAddressFromFavoritesCommandBuilder(
-        IMediator mediator,
         IAuthorizationService authorizationService,
         IProfileAuthorizationService profileAuthorizationService)
-        : base(mediator, authorizationService)
+        : base(authorizationService)
     {
         _profileAuthorizationService = profileAuthorizationService;
+    }
+
+    [Obsolete("Use the constructor without IMediator. The mediator is resolved from context.RequestServices per request.", DiagnosticId = "VC0015", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
+    public RemoveAddressFromFavoritesCommandBuilder(IMediator mediator, IAuthorizationService authorizationService, IProfileAuthorizationService profileAuthorizationService)
+        : this(authorizationService, profileAuthorizationService)
+    {
     }
 
     protected override RemoveAddressFromFavoritesCommand GetRequest(IResolveFieldContext<object> context)

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/SendPasswordResetEmailCommandBuilder.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/SendPasswordResetEmailCommandBuilder.cs
@@ -1,4 +1,5 @@
-﻿using GraphQL.Types;
+﻿using System;
+using GraphQL.Types;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using VirtoCommerce.Xapi.Core.BaseQueries;
@@ -9,7 +10,13 @@ public class SendPasswordResetEmailCommandBuilder : CommandBuilder<SendPasswordR
 {
     protected override string Name => "sendPasswordResetEmail";
 
-    public SendPasswordResetEmailCommandBuilder(IMediator mediator, IAuthorizationService authorizationService) : base(mediator, authorizationService)
+    public SendPasswordResetEmailCommandBuilder(IAuthorizationService authorizationService) : base(authorizationService)
+    {
+    }
+
+    [Obsolete("Use the constructor without IMediator. The mediator is resolved from context.RequestServices per request.", DiagnosticId = "VC0015", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
+    public SendPasswordResetEmailCommandBuilder(IMediator mediator, IAuthorizationService authorizationService)
+        : this(authorizationService)
     {
     }
 }

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Extensions/SchemaExtensions.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Extensions/SchemaExtensions.cs
@@ -7,13 +7,14 @@ using MediatR;
 using VirtoCommerce.ProfileExperienceApiModule.Data.Aggregates;
 using VirtoCommerce.ProfileExperienceApiModule.Data.Queries;
 using VirtoCommerce.ProfileExperienceApiModule.Data.Schemas;
+using VirtoCommerce.Xapi.Core.Extensions;
 using VirtoCommerce.Xapi.Core.Helpers;
 
 namespace VirtoCommerce.ProfileExperienceApiModule.Data.Extensions;
 
 public static class SchemaExtensions
 {
-    public static void AddMemberQuery<TAggregate, TType, TQuery>(this ISchema schema, IMediator mediator, string name, Func<IResolveFieldContext, object, Task> checkAuthAsync)
+    public static void AddMemberQuery<TAggregate, TType, TQuery>(this ISchema schema, string name, Func<IResolveFieldContext, object, Task> checkAuthAsync)
         where TAggregate : MemberAggregateRootBase
         where TType : MemberBaseType<TAggregate>
         where TQuery : GetMemberByIdQueryBase<TAggregate>, new()
@@ -29,7 +30,7 @@ public static class SchemaExtensions
             Resolver = new FuncFieldResolver<object>(async context =>
             {
                 var query = new TQuery { Id = context.GetArgument<string>("id") };
-                var aggregate = await mediator.Send(query);
+                var aggregate = await context.GetMediator().Send(query);
 
                 await checkAuthAsync(context, aggregate);
 
@@ -39,5 +40,14 @@ public static class SchemaExtensions
                 return aggregate;
             })
         });
+    }
+
+    [Obsolete("Use the overload without IMediator. The mediator is resolved from context.RequestServices per request.", DiagnosticId = "VC0015", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
+    public static void AddMemberQuery<TAggregate, TType, TQuery>(this ISchema schema, IMediator mediator, string name, Func<IResolveFieldContext, object, Task> checkAuthAsync)
+        where TAggregate : MemberAggregateRootBase
+        where TType : MemberBaseType<TAggregate>
+        where TQuery : GetMemberByIdQueryBase<TAggregate>, new()
+    {
+        schema.AddMemberQuery<TAggregate, TType, TQuery>(name, checkAuthAsync);
     }
 }

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Queries/AddressesQuery/BaseAddressesQueryBuilder.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Queries/AddressesQuery/BaseAddressesQueryBuilder.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using GraphQL;
 using GraphQL.Types;
@@ -17,10 +18,16 @@ public abstract class BaseAddressesQueryBuilder<TQuery> : SearchQueryBuilder<TQu
 {
     private readonly IProfileAuthorizationService _profileAuthorizationService;
 
-    protected BaseAddressesQueryBuilder(IMediator mediator, IAuthorizationService authorizationService, IProfileAuthorizationService profileAuthorizationService)
-        : base(mediator, authorizationService)
+    protected BaseAddressesQueryBuilder(IAuthorizationService authorizationService, IProfileAuthorizationService profileAuthorizationService)
+        : base(authorizationService)
     {
         _profileAuthorizationService = profileAuthorizationService;
+    }
+
+    [Obsolete("Use the constructor without IMediator. The mediator is resolved from context.RequestServices per request.", DiagnosticId = "VC0015", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
+    protected BaseAddressesQueryBuilder(IMediator mediator, IAuthorizationService authorizationService, IProfileAuthorizationService profileAuthorizationService)
+        : this(authorizationService, profileAuthorizationService)
+    {
     }
 
     protected override FieldType GetFieldType()

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Queries/AddressesQuery/CurrentCustomerAddressesQueryBuilder.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Queries/AddressesQuery/CurrentCustomerAddressesQueryBuilder.cs
@@ -1,3 +1,4 @@
+using System;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using VirtoCommerce.ProfileExperienceApiModule.Data.Services;
@@ -8,8 +9,14 @@ public class CurrentCustomerAddressesQueryBuilder : BaseAddressesQueryBuilder<Cu
 {
     protected override string Name => "currentCustomerAddresses";
 
+    public CurrentCustomerAddressesQueryBuilder(IAuthorizationService authorizationService, IProfileAuthorizationService profileAuthorizationService)
+        : base(authorizationService, profileAuthorizationService)
+    {
+    }
+
+    [Obsolete("Use the constructor without IMediator. The mediator is resolved from context.RequestServices per request.", DiagnosticId = "VC0015", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
     public CurrentCustomerAddressesQueryBuilder(IMediator mediator, IAuthorizationService authorizationService, IProfileAuthorizationService profileAuthorizationService)
-        : base(mediator, authorizationService, profileAuthorizationService)
+        : this(authorizationService, profileAuthorizationService)
     {
     }
 }

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Queries/AddressesQuery/CurrentOrganizationAddressesQueryBuilder.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Queries/AddressesQuery/CurrentOrganizationAddressesQueryBuilder.cs
@@ -1,3 +1,4 @@
+using System;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using VirtoCommerce.ProfileExperienceApiModule.Data.Services;
@@ -8,8 +9,14 @@ public class CurrentOrganizationAddressesQueryBuilder : BaseAddressesQueryBuilde
 {
     protected override string Name => "currentOrganizationAddresses";
 
+    public CurrentOrganizationAddressesQueryBuilder(IAuthorizationService authorizationService, IProfileAuthorizationService profileAuthorizationService)
+        : base(authorizationService, profileAuthorizationService)
+    {
+    }
+
+    [Obsolete("Use the constructor without IMediator. The mediator is resolved from context.RequestServices per request.", DiagnosticId = "VC0015", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
     public CurrentOrganizationAddressesQueryBuilder(IMediator mediator, IAuthorizationService authorizationService, IProfileAuthorizationService profileAuthorizationService)
-        : base(mediator, authorizationService, profileAuthorizationService)
+        : this(authorizationService, profileAuthorizationService)
     {
     }
 }

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Schemas/ContactType.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Schemas/ContactType.cs
@@ -41,7 +41,6 @@ public class ContactType : MemberBaseType<ContactAggregate>
         Func<UserManager<ApplicationUser>> userManagerFactory,
         Func<RoleManager<Role>> roleManagerFactory,
         ICustomerPreferenceService customerPreferenceService,
-        IMediator mediator,
         IMemberAggregateFactory memberAggregateFactory,
         IOrganizationMembershipSearchService organizationMembershipSearchService,
         IDataLoaderContextAccessor dataLoader)
@@ -90,7 +89,7 @@ public class ContactType : MemberBaseType<ContactAggregate>
             {
                 Id = organizationId,
             };
-            return await mediator.Send(query);
+            return await context.GetMediator().Send(query);
         });
 
         Field<StringGraphType>("selectedAddressId")
@@ -118,7 +117,7 @@ public class ContactType : MemberBaseType<ContactAggregate>
             {
                 query.DeepSearch = true;
                 query.ObjectIds = context.Source.Contact.Organizations;
-                response = await mediator.Send(query);
+                response = await context.GetMediator().Send(query);
             }
 
             return new PagedConnection<OrganizationAggregate>(
@@ -128,6 +127,22 @@ public class ContactType : MemberBaseType<ContactAggregate>
         AddField(organizationsConnectionBuilder.FieldType);
 
         #endregion
+    }
+
+    [Obsolete("Use the constructor without IMediator. The mediator is resolved from context.RequestServices per request.", DiagnosticId = "VC0015", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
+    public ContactType(
+        IStoreService storeService,
+        IDynamicPropertyResolverService dynamicPropertyResolverService,
+        IMemberAddressService memberAddressService,
+        Func<UserManager<ApplicationUser>> userManagerFactory,
+        Func<RoleManager<Role>> roleManagerFactory,
+        ICustomerPreferenceService customerPreferenceService,
+        IMediator mediator,
+        IMemberAggregateFactory memberAggregateFactory,
+        IOrganizationMembershipSearchService organizationMembershipSearchService,
+        IDataLoaderContextAccessor dataLoader)
+        : this(storeService, dynamicPropertyResolverService, memberAddressService, userManagerFactory, roleManagerFactory, customerPreferenceService, memberAggregateFactory, organizationMembershipSearchService, dataLoader)
+    {
     }
 
     private static IDataLoaderResult<bool> ResolveIsLockedInOrganization(

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Schemas/OrganizationType.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Schemas/OrganizationType.cs
@@ -19,6 +19,7 @@ using VirtoCommerce.ProfileExperienceApiModule.Data.Commands;
 using VirtoCommerce.ProfileExperienceApiModule.Data.Extensions;
 using VirtoCommerce.ProfileExperienceApiModule.Data.Services;
 using VirtoCommerce.StoreModule.Core.Services;
+using VirtoCommerce.Xapi.Core.Extensions;
 using VirtoCommerce.Xapi.Core.Helpers;
 using VirtoCommerce.Xapi.Core.Infrastructure;
 using VirtoCommerce.Xapi.Core.Services;
@@ -31,7 +32,6 @@ public class OrganizationType : MemberBaseType<OrganizationAggregate>
         IStoreService storeService,
         IDynamicPropertyResolverService dynamicPropertyResolverService,
         IMemberAddressService memberAddressService,
-        IMediator mediator,
         IMemberAggregateFactory factory,
         IMemberService memberService,
         IMemberSearchService memberSearchService,
@@ -86,7 +86,7 @@ public class OrganizationType : MemberBaseType<OrganizationAggregate>
                 }
             }
 
-            var response = await mediator.Send(query);
+            var response = await context.GetMediator().Send(query);
 
             return new PagedConnection<ContactAggregate>(
                 response.Results.Select(x => factory.Create<ContactAggregate>(x)), query.Skip, query.Take,
@@ -95,6 +95,22 @@ public class OrganizationType : MemberBaseType<OrganizationAggregate>
         AddField(connectionBuilder.FieldType);
 
         #endregion
+    }
+
+    [Obsolete("Use the constructor without IMediator. The mediator is resolved from context.RequestServices per request.", DiagnosticId = "VC0015", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
+    public OrganizationType(
+        IStoreService storeService,
+        IDynamicPropertyResolverService dynamicPropertyResolverService,
+        IMemberAddressService memberAddressService,
+        IMediator mediator,
+        IMemberAggregateFactory factory,
+        IMemberService memberService,
+        IMemberSearchService memberSearchService,
+        IOrganizationMembershipSearchService organizationMembershipService,
+        Func<RoleManager<Role>> roleManagerFactory,
+        Func<UserManager<ApplicationUser>> userManagerFactory)
+        : this(storeService, dynamicPropertyResolverService, memberAddressService, factory, memberService, memberSearchService, organizationMembershipService, roleManagerFactory, userManagerFactory)
+    {
     }
 
     private static async Task<IReadOnlyCollection<string>> GetContactIdsByGlobalRolesAsync(

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Schemas/ProfileSchema.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Schemas/ProfileSchema.cs
@@ -41,24 +41,32 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Schemas
     {
         public const string _commandName = "command";
 
-        private readonly IMediator _mediator;
         private readonly IAuthorizationService _authorizationService;
         private readonly Func<SignInManager<ApplicationUser>> _signInManagerFactory;
         private readonly IMemberAggregateFactory _factory;
         private readonly ILogger<ProfileSchema> _logger;
 
         public ProfileSchema(
-            IMediator mediator,
             IAuthorizationService authorizationService,
             Func<SignInManager<ApplicationUser>> signInManagerFactory,
             IMemberAggregateFactory factory,
             ILogger<ProfileSchema> logger)
         {
-            _mediator = mediator;
             _authorizationService = authorizationService;
             _signInManagerFactory = signInManagerFactory;
             _factory = factory;
             _logger = logger;
+        }
+
+        [Obsolete("Use the constructor without IMediator. The mediator is resolved from context.RequestServices per request.", DiagnosticId = "VC0015", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
+        public ProfileSchema(
+            IMediator mediator,
+            IAuthorizationService authorizationService,
+            Func<SignInManager<ApplicationUser>> signInManagerFactory,
+            IMemberAggregateFactory factory,
+            ILogger<ProfileSchema> logger)
+            : this(authorizationService, signInManagerFactory, factory, logger)
+        {
         }
 
         public void Build(ISchema schema)
@@ -79,7 +87,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Schemas
                     var userName = principal?.Identity?.Name;
                     if (!string.IsNullOrEmpty(userName))
                     {
-                        var result = await _mediator.Send(new GetUserQuery
+                        var result = await context.GetMediator().Send(new GetUserQuery
                         {
                             UserName = userName
                         });
@@ -101,13 +109,13 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Schemas
             });
 
             schema.AddMemberQuery<OrganizationAggregate, OrganizationType, GetOrganizationByIdQuery>(
-                _mediator, "organization", (context, aggregate) => CheckAuthAsync(context, aggregate));
+                "organization", (context, aggregate) => CheckAuthAsync(context, aggregate));
 
             schema.AddMemberQuery<ContactAggregate, ContactType, GetContactByIdQuery>(
-                _mediator, "contact", (context, aggregate) => CheckAuthAsync(context, aggregate));
+                "contact", (context, aggregate) => CheckAuthAsync(context, aggregate));
 
             schema.AddMemberQuery<VendorAggregate, VendorType, GetVendorByIdQuery>(
-                _mediator, "vendor", (context, aggregate) => CheckAuthAsync(context, aggregate));
+                "vendor", (context, aggregate) => CheckAuthAsync(context, aggregate));
 
             var organizationsConnectionBuilder = GraphTypeExtensionHelper
                 .CreateConnection<OrganizationType, object>("organizations")
@@ -125,7 +133,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Schemas
                 query.DeepSearch = true;
                 query.UserId = context.GetCurrentPrincipal()?.FindFirstValue(ClaimTypes.NameIdentifier);
 
-                var response = await _mediator.Send(query);
+                var response = await context.GetMediator().Send(query);
 
                 return new PagedConnection<OrganizationAggregate>(response.Results.Select(x => _factory.Create<OrganizationAggregate>(x)), query.Skip, query.Take, response.TotalCount);
             });
@@ -147,7 +155,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Schemas
                 var query = context.GetSearchMembersQuery<SearchContactsQuery>();
                 query.DeepSearch = true;
 
-                var response = await _mediator.Send(query);
+                var response = await context.GetMediator().Send(query);
 
                 return new PagedConnection<ContactAggregate>(response.Results.Select(x => _factory.Create<ContactAggregate>(x)), query.Skip, query.Take, response.TotalCount);
             });
@@ -169,7 +177,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Schemas
                 Type = GraphTypeExtensionHelper.GetActualType<BooleanGraphType>(),
                 Resolver = new FuncFieldResolver<object>(async context =>
                 {
-                    var result = await _mediator.Send(new CheckUsernameUniquenessQuery
+                    var result = await context.GetMediator().Send(new CheckUsernameUniquenessQuery
                     {
                         Username = context.GetArgument<string>("username"),
                     });
@@ -193,7 +201,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Schemas
                 Type = GraphTypeExtensionHelper.GetActualType<BooleanGraphType>(),
                 Resolver = new FuncFieldResolver<object>(async context =>
                 {
-                    var result = await _mediator.Send(new CheckEmailUniquenessQuery
+                    var result = await context.GetMediator().Send(new CheckEmailUniquenessQuery
                     {
                         Email = context.GetArgument<string>("email"),
                     });
@@ -222,7 +230,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Schemas
                 Type = GraphTypeExtensionHelper.GetActualType<AddressDuplicatedResultType>(),
                 Resolver = new FuncFieldResolver<object>(async context =>
                 {
-                    var result = await _mediator.Send(new CheckDuplicateAddressQuery
+                    var result = await context.GetMediator().Send(new CheckDuplicateAddressQuery
                     {
                         MemberId = context.GetArgument<string>("memberId"),
                         Address = context.GetArgument<MemberAddress>("address"),
@@ -251,7 +259,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Schemas
                 Type = GraphTypeExtensionHelper.GetActualType<BooleanGraphType>(),
                 Resolver = new FuncFieldResolver<object>(async context =>
                 {
-                    var result = await _mediator.Send(new RequestPasswordResetQuery
+                    var result = await context.GetMediator().Send(new RequestPasswordResetQuery
                     {
                         StoreId = context.GetArgument<string>("storeId"),
                         CultureName = context.GetArgument<string>("cultureName"),
@@ -278,7 +286,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Schemas
                 Type = GraphTypeExtensionHelper.GetActualType<CustomIdentityResultType>(),
                 Resolver = new FuncFieldResolver<object>(async context =>
                 {
-                    var result = await _mediator.Send(new PasswordValidationQuery
+                    var result = await context.GetMediator().Send(new PasswordValidationQuery
                     {
                         Password = context.GetArgument<string>("password"),
                     });
@@ -319,7 +327,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Schemas
                                 var type = GenericTypeHelper.GetActualType<UpdateMemberAddressesCommand>();
                                 var command = (UpdateMemberAddressesCommand)context.GetArgument(type, _commandName);
                                 await CheckAuthAsync(context, command);
-                                return await _mediator.Send(command);
+                                return await context.GetMediator().Send(command);
                             })
                             .FieldType);
 
@@ -331,7 +339,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Schemas
                                 var type = GenericTypeHelper.GetActualType<DeleteMemberAddressesCommand>();
                                 var command = (DeleteMemberAddressesCommand)context.GetArgument(type, _commandName);
                                 await CheckAuthAsync(context, command);
-                                return await _mediator.Send(command);
+                                return await context.GetMediator().Send(command);
                             })
                             .FieldType);
 
@@ -343,7 +351,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Schemas
                                 var type = GenericTypeHelper.GetActualType<UpdateOrganizationCommand>();
                                 var command = (UpdateOrganizationCommand)context.GetArgument(type, _commandName);
                                 await CheckAuthAsync(context, command, ProfilePermissions.MyOrganizationEdit);
-                                return await _mediator.Send(command);
+                                return await context.GetMediator().Send(command);
                             })
                             .FieldType);
 
@@ -355,7 +363,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Schemas
                                 var type = GenericTypeHelper.GetActualType<CreateOrganizationCommand>();
                                 var command = (CreateOrganizationCommand)context.GetArgument(type, _commandName);
                                 await CheckAuthAsync(context, command);
-                                return await _mediator.Send(command);
+                                return await context.GetMediator().Send(command);
                             })
                             .FieldType);
 
@@ -367,7 +375,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Schemas
                                 var type = GenericTypeHelper.GetActualType<RemoveMemberFromOrganizationCommand>();
                                 var command = (RemoveMemberFromOrganizationCommand)context.GetArgument(type, _commandName);
                                 await CheckAuthAsync(context, command, ProfilePermissions.MyOrganizationEdit);
-                                return await _mediator.Send(command);
+                                return await context.GetMediator().Send(command);
                             })
                             .FieldType);
 
@@ -378,7 +386,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Schemas
                             {
                                 var type = GenericTypeHelper.GetActualType<RegisterRequestCommand>();
                                 var command = (RegisterRequestCommand)context.GetArgument(type, _commandName);
-                                return await _mediator.Send(command);
+                                return await context.GetMediator().Send(command);
                             })
                             .FieldType);
 
@@ -391,7 +399,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Schemas
                                 var command = (CreateContactCommand)context.GetArgument(type, _commandName);
                                 await CheckAuthAsync(context, command);
 
-                                return await _mediator.Send(command);
+                                return await context.GetMediator().Send(command);
                             })
                             .FieldType);
 
@@ -405,7 +413,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Schemas
                                 command.UserId = context.GetCurrentUserId();
                                 command.OrganizationId = context.GetCurrentOrganizationId();
                                 await CheckAuthAsync(context, command);
-                                return await _mediator.Send(command);
+                                return await context.GetMediator().Send(command);
 
                             })
                             .FieldType);
@@ -418,7 +426,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Schemas
                                 var type = GenericTypeHelper.GetActualType<DeleteContactCommand>();
                                 var command = (DeleteContactCommand)context.GetArgument(type, _commandName);
                                 await CheckAuthAsync(context, command, CustomerPermissions.Delete);
-                                return await _mediator.Send(command);
+                                return await context.GetMediator().Send(command);
                             })
                             .FieldType);
 
@@ -430,7 +438,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Schemas
                               var type = GenericTypeHelper.GetActualType<UpdatePersonalDataCommand>();
                               var command = (UpdatePersonalDataCommand)context.GetArgument(type, _commandName);
                               await CheckAuthAsync(context, command);
-                              return await _mediator.Send(command);
+                              return await context.GetMediator().Send(command);
                           })
                           .FieldType);
 
@@ -443,7 +451,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Schemas
                             var command = (UpdateMemberDynamicPropertiesCommand)context.GetArgument(type, _commandName);
                             await CheckAuthAsync(context, command, CustomerPermissions.Update);
 
-                            return await _mediator.Send(command);
+                            return await context.GetMediator().Send(command);
                         })
                         .FieldType);
 
@@ -461,7 +469,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Schemas
                                 command.Email = await GetUserEmailAsync(context.GetCurrentUserId());
                             }
 
-                            return await _mediator.Send(command);
+                            return await context.GetMediator().Send(command);
                         })
                         .FieldType);
 
@@ -473,7 +481,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Schemas
                             var type = GenericTypeHelper.GetActualType<ConfirmEmailCommand>();
                             var command = (ConfirmEmailCommand)context.GetArgument(type, _commandName);
 
-                            return await _mediator.Send(command);
+                            return await context.GetMediator().Send(command);
                         })
                         .FieldType);
 
@@ -485,7 +493,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Schemas
                             var type = GenericTypeHelper.GetActualType<ResetPasswordByTokenCommand>();
                             var command = (ResetPasswordByTokenCommand)context.GetArgument(type, _commandName);
 
-                            return await _mediator.Send(command);
+                            return await context.GetMediator().Send(command);
                         })
                         .FieldType);
 
@@ -500,7 +508,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Schemas
 
                             command.SessionGroupId = context.User.FindFirstValue(OpenIddictConstants.Claims.Private.AuthorizationId);
 
-                            return await _mediator.Send(command);
+                            return await context.GetMediator().Send(command);
                         })
                         .FieldType);
 
@@ -513,7 +521,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Schemas
                             var command = (LockOrganizationContactCommand)context.GetArgument(type, _commandName);
                             command.OrganizationId = context.GetCurrentOrganizationId();
                             await CheckAuthAsync(context, command, ProfilePermissions.MyOrganizationEdit);
-                            return await _mediator.Send(command);
+                            return await context.GetMediator().Send(command);
                         })
                         .FieldType);
 
@@ -526,7 +534,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Schemas
                             var command = (UnlockOrganizationContactCommand)context.GetArgument(type, _commandName);
                             command.OrganizationId = context.GetCurrentOrganizationId();
                             await CheckAuthAsync(context, command, ProfilePermissions.MyOrganizationEdit);
-                            return await _mediator.Send(command);
+                            return await context.GetMediator().Send(command);
                         })
                         .FieldType);
 
@@ -557,7 +565,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Schemas
                 Type = GraphTypeExtensionHelper.GetActualType<UserType>(),
                 Resolver = new FuncFieldResolver<object>(async context =>
                 {
-                    var user = await _mediator.Send(new GetUserQuery(
+                    var user = await context.GetMediator().Send(new GetUserQuery(
                         id: context.GetArgument<string>("id"),
                         email: context.GetArgument<string>("email"),
                         userName: context.GetArgument<string>("userName"),
@@ -592,7 +600,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Schemas
                 Type = GraphTypeExtensionHelper.GetActualType<RoleType>(),
                 Resolver = new FuncFieldResolver<object>(async context =>
                 {
-                    var result = await _mediator.Send(new GetRoleQuery(context.GetArgument<string>("roleName")));
+                    var result = await context.GetMediator().Send(new GetRoleQuery(context.GetArgument<string>("roleName")));
 
                     return result;
                 })
@@ -628,7 +636,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Schemas
                             var type = GenericTypeHelper.GetActualType<InviteUserCommand>();
                             var command = (InviteUserCommand)context.GetArgument(type, _commandName);
                             await CheckAuthAsync(context, command, ProfilePermissions.MyOrganizationUserInvite);
-                            return await _mediator.Send(command);
+                            return await context.GetMediator().Send(command);
                         })
                         .FieldType);
 
@@ -662,7 +670,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Schemas
                         {
                             var type = GenericTypeHelper.GetActualType<RegisterByInvitationCommand>();
                             var command = (RegisterByInvitationCommand)context.GetArgument(type, _commandName);
-                            return await _mediator.Send(command);
+                            return await context.GetMediator().Send(command);
                         })
                         .FieldType);
 
@@ -691,7 +699,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Schemas
                             var type = GenericTypeHelper.GetActualType<CreateUserCommand>();
                             var command = (CreateUserCommand)context.GetArgument(type, _commandName);
                             await CheckAuthAsync(context, command);
-                            return await _mediator.Send(command);
+                            return await context.GetMediator().Send(command);
                         })
                         .FieldType);
 
@@ -725,7 +733,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Schemas
                             var type = GenericTypeHelper.GetActualType<UpdateUserCommand>();
                             var command = (UpdateUserCommand)context.GetArgument(type, _commandName);
                             await CheckAuthAsync(context, command);
-                            return await _mediator.Send(command);
+                            return await context.GetMediator().Send(command);
                         })
                         .FieldType);
 
@@ -738,7 +746,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Schemas
                             var command = (ChangeOrganizationContactRoleCommand)context.GetArgument(type, _commandName);
                             command.OrganizationId = context.GetCurrentOrganizationId();
                             await CheckAuthAsync(context, command, ProfilePermissions.MyOrganizationEdit);
-                            return await _mediator.Send(command);
+                            return await context.GetMediator().Send(command);
                         })
             .FieldType);
 
@@ -767,7 +775,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Schemas
                             var type = GenericTypeHelper.GetActualType<DeleteUserCommand>();
                             var command = (DeleteUserCommand)context.GetArgument(type, _commandName);
                             await CheckAuthAsync(context, command, PlatformPermissions.SecurityDelete);
-                            return await _mediator.Send(command);
+                            return await context.GetMediator().Send(command);
                         })
                         .FieldType);
 
@@ -799,7 +807,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Schemas
                             var command = (UpdateRoleCommand)context.GetArgument(type, _commandName);
                             await CheckAuthAsync(context, command, PlatformPermissions.SecurityUpdate);
 
-                            return await _mediator.Send(command);
+                            return await context.GetMediator().Send(command);
                         })
                         .FieldType);
         }

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Schemas/UserType.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Schemas/UserType.cs
@@ -19,7 +19,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Schemas
 {
     public class UserType : ExtendableGraphType<ApplicationUser>
     {
-        public UserType(IContactAggregateRepository contactAggregateRepository, IUserManagerCore userManagerCore, IMediator mediator, IOptions<UserOptionsExtended> userOptionsExtended)
+        public UserType(IContactAggregateRepository contactAggregateRepository, IUserManagerCore userManagerCore, IOptions<UserOptionsExtended> userOptionsExtended)
         {
             Field(x => x.AccessFailedCount);
             Field(x => x.CreatedBy, true);
@@ -99,7 +99,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Schemas
                 {
                     if (context.UserContext.TryGetValue("OperatorUserName", out var operatorUser))
                     {
-                        var result = await mediator.Send(new GetUserQuery
+                        var result = await context.GetMediator().Send(new GetUserQuery
                         {
                             UserName = operatorUser as string
                         });
@@ -109,6 +109,12 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Schemas
                     return null;
                 })
             });
+        }
+
+        [Obsolete("Use the constructor without IMediator. The mediator is resolved from context.RequestServices per request.", DiagnosticId = "VC0015", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
+        public UserType(IContactAggregateRepository contactAggregateRepository, IUserManagerCore userManagerCore, IMediator mediator, IOptions<UserOptionsExtended> userOptionsExtended)
+            : this(contactAggregateRepository, userManagerCore, userOptionsExtended)
+        {
         }
 
         private static bool GetPasswordExpired(IResolveFieldContext<ApplicationUser> context)

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/VirtoCommerce.ProfileExperienceApiModule.Data.csproj
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/VirtoCommerce.ProfileExperienceApiModule.Data.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.1039.0" />
     <PackageReference Include="VirtoCommerce.PricingModule.Core" Version="3.1003.0" />
     <PackageReference Include="VirtoCommerce.TaxModule.Core" Version="3.1003.0" />
-    <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.1012.0" />
+    <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.1015.0" />
     <PackageReference Include="VirtoCommerce.XOrder.Core" Version="3.1005.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Web/module.manifest
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Web/module.manifest
@@ -11,7 +11,7 @@
     <dependency id="VirtoCommerce.Notifications" version="3.1009.0" />
     <dependency id="VirtoCommerce.Pricing" version="3.1003.0" optional="true" />
     <dependency id="VirtoCommerce.Tax" version="3.1003.0" optional="true" />
-    <dependency id="VirtoCommerce.Xapi" version="3.1012.0" />
+    <dependency id="VirtoCommerce.Xapi" version="3.1015.0" />
     <dependency id="VirtoCommerce.XOrder" version="3.1005.0" optional="true" />
   </dependencies>
 

--- a/tests/VirtoCommerce.ProfileExperienceApiModule.Tests/Schemas/ContactTypeTests.cs
+++ b/tests/VirtoCommerce.ProfileExperienceApiModule.Tests/Schemas/ContactTypeTests.cs
@@ -4,7 +4,6 @@ using System.Security.Claims;
 using System.Threading.Tasks;
 using GraphQL;
 using GraphQL.DataLoader;
-using MediatR;
 using Microsoft.AspNetCore.Identity;
 using Moq;
 using VirtoCommerce.CustomerModule.Core;
@@ -48,7 +47,6 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Tests.Schemas
                 () => _userManagerMock.Object,
                 () => _roleManagerMock.Object,
                 new Mock<ICustomerPreferenceService>().Object,
-                new Mock<IMediator>().Object,
                 new Mock<IMemberAggregateFactory>().Object,
                 _membershipSearchServiceMock.Object,
                 new DataLoaderContextAccessor { Context = new DataLoaderContext() });


### PR DESCRIPTION
## Description

GraphQL schemas, graph types, and query/command builders are created once while the schema is built. Injecting `IMediator` into those constructors captures the root service provider; a request dispatched through it can therefore resolve scoped handler dependencies from the wrong scope.

This change upgrades XApi to `3.1015.0` and resolves the mediator from the active GraphQL request through `context.GetMediator()` immediately before dispatch. It updates ProfileSchema, member GraphQL types, member query extension, and address/password command and query builders.

Existing public and protected constructors that accept `IMediator` remain as obsolete compatibility overloads. They delegate to the mediator-free constructors, so existing consumers continue to compile without retaining a mediator in a singleton.

## References
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5468

### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.ProfileExperienceApiModule_3.1014.0-pr-140-ad82.zip
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wide touch across profile GraphQL queries/mutations (users, passwords, org membership) but behavior should be equivalent with correct scoping; main risk is regression if `GetMediator()` is unavailable in some resolve paths.
> 
> **Overview**
> Fixes a **DI scope bug** where `IMediator` injected into long-lived GraphQL schema/types captured the root provider, so MediatR handlers could resolve scoped dependencies outside the active request.
> 
> The module bumps **VirtoCommerce.Xapi** to **3.1015.0** and switches dispatch to **`context.GetMediator()`** at field resolution time across `ProfileSchema`, member graph types (`ContactType`, `OrganizationType`, `UserType`), `AddMemberQuery`, and address/password command & query builders. Constructors no longer take `IMediator`; **obsolete overloads** (diagnostic **VC0015**) delegate to the new APIs so existing subclasses still compile.
> 
> Tests (e.g. `ContactTypeTests`) are updated to construct types without a mediator mock.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad8214cdf46daea5c60efc0b4f44d9732abb16dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->