### PR TITLE
VCST-5281: Added Organization Invite and Status for Multi Organization customers

### DIFF
--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Authorization/ProfileAuthorizationHandler.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Authorization/ProfileAuthorizationHandler.cs
@@ -158,6 +158,18 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Authorization
                 case RemoveMemberFromOrganizationCommand removeMemberFromOrganizationCommand:
                     result = await HasSameOrganizationAsync(currentContact, removeMemberFromOrganizationCommand.ContactId, userManager);
                     break;
+                case AcceptOrganizationInviteCommand acceptOrganizationInviteCommand:
+                    result = acceptOrganizationInviteCommand.UserId == currentUserId;
+                    break;
+                case RejectOrganizationInviteCommand rejectOrganizationInviteCommand:
+                    result = rejectOrganizationInviteCommand.UserId == currentUserId;
+                    break;
+                case RevokeOrganizationInviteCommand revokeOrganizationInviteCommand:
+                    result = await HasSameOrganizationAsync(currentContact, revokeOrganizationInviteCommand.MemberId, userManager);
+                    break;
+                case ResendOrganizationInviteCommand resendOrganizationInviteCommand:
+                    result = await HasSameOrganizationAsync(currentContact, resendOrganizationInviteCommand.MemberId, userManager);
+                    break;
                 case ChangePasswordCommand changePasswordCommand:
                     result = changePasswordCommand.UserId == currentUserId;
                     break;

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Authorization/ProfileAuthorizationHandler.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Authorization/ProfileAuthorizationHandler.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
+using VirtoCommerce.CustomerModule.Core.Extensions;
 using VirtoCommerce.CustomerModule.Core.Model;
 using VirtoCommerce.CustomerModule.Core.Services;
 using VirtoCommerce.Platform.Core;
@@ -14,18 +15,24 @@ using VirtoCommerce.ProfileExperienceApiModule.Data.Aggregates.Vendor;
 using VirtoCommerce.ProfileExperienceApiModule.Data.Commands;
 using VirtoCommerce.ProfileExperienceApiModule.Data.Queries;
 using VirtoCommerce.ProfileExperienceApiModule.Data.Queries.AddressesQuery;
+using CustomerModuleConstants = VirtoCommerce.CustomerModule.Core.ModuleConstants;
 
 namespace VirtoCommerce.ProfileExperienceApiModule.Data.Authorization
 {
     public class ProfileAuthorizationHandler : AuthorizationHandler<ProfileAuthorizationRequirement>
     {
         private readonly IMemberService _memberService;
+        private readonly IOrganizationMembershipSearchService _organizationMembershipSearchService;
         private readonly Func<UserManager<ApplicationUser>> _userManagerFactory;
 
 
-        public ProfileAuthorizationHandler(IMemberService memberService, Func<UserManager<ApplicationUser>> userManagerFactory)
+        public ProfileAuthorizationHandler(
+            IMemberService memberService,
+            IOrganizationMembershipSearchService organizationMembershipSearchService,
+            Func<UserManager<ApplicationUser>> userManagerFactory)
         {
             _memberService = memberService;
+            _organizationMembershipSearchService = organizationMembershipSearchService;
             _userManagerFactory = userManagerFactory;
         }
 
@@ -58,7 +65,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Authorization
                     result = result || await HasSameOrganizationAsync(currentContact, applicationUser.Id, userManager);
                     break;
                 case OrganizationAggregate organizationAggregate when currentContact != null:
-                    result = currentContact.Organizations.Contains(organizationAggregate.Organization.Id);
+                    result = await HasActiveAccessToOrganizationAsync(currentContact, currentUserId, organizationAggregate.Organization.Id);
                     break;
                 case VendorAggregate:
                     result = true;
@@ -219,6 +226,24 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Authorization
             }
 
             return result;
+        }
+
+        private async Task<bool> HasActiveAccessToOrganizationAsync(Contact currentContact, string userId, string organizationId)
+        {
+            if (!currentContact.Organizations.Contains(organizationId))
+            {
+                return false;
+            }
+
+            var membership = await _organizationMembershipSearchService.GetMembershipAsync(userId, organizationId);
+            if (membership?.IsCurrentlyLocked == true)
+            {
+                return false;
+            }
+
+            var effectiveStatus = OrganizationMembership.ResolveEffectiveStatus(membership?.Status, currentContact.Status);
+
+            return !CustomerModuleConstants.MembershipStatuses.IsBlocking(effectiveStatus);
         }
 
         private async Task<bool> HasSameOrganizationAsync(Contact currentContact, string contactId, UserManager<ApplicationUser> userManager)

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/AcceptOrganizationInviteCommand.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/AcceptOrganizationInviteCommand.cs
@@ -1,0 +1,12 @@
+using VirtoCommerce.ProfileExperienceApiModule.Data.Aggregates.Contact;
+using VirtoCommerce.Xapi.Core.Infrastructure;
+
+namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
+{
+    public class AcceptOrganizationInviteCommand : ICommand<ContactAggregate>
+    {
+        public string UserId { get; set; }
+
+        public string OrganizationId { get; set; }
+    }
+}

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/AcceptOrganizationInviteCommandHandler.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/AcceptOrganizationInviteCommandHandler.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using Microsoft.AspNetCore.Identity;
+using VirtoCommerce.CustomerModule.Core.Services;
+using VirtoCommerce.Platform.Core.Security;
+using VirtoCommerce.ProfileExperienceApiModule.Data.Aggregates.Contact;
+
+namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
+{
+    public class AcceptOrganizationInviteCommandHandler : IRequestHandler<AcceptOrganizationInviteCommand, ContactAggregate>
+    {
+        private readonly IContactAggregateRepository _contactAggregateRepository;
+        private readonly IOrganizationMembershipService _organizationMembershipService;
+        private readonly IOrganizationMembershipSearchService _organizationMembershipSearchService;
+        private readonly Func<UserManager<ApplicationUser>> _userManagerFactory;
+
+        public AcceptOrganizationInviteCommandHandler(
+            IContactAggregateRepository contactAggregateRepository,
+            IOrganizationMembershipService organizationMembershipService,
+            IOrganizationMembershipSearchService organizationMembershipSearchService,
+            Func<UserManager<ApplicationUser>> userManagerFactory)
+        {
+            _contactAggregateRepository = contactAggregateRepository;
+            _organizationMembershipService = organizationMembershipService;
+            _organizationMembershipSearchService = organizationMembershipSearchService;
+            _userManagerFactory = userManagerFactory;
+        }
+
+        public virtual async Task<ContactAggregate> Handle(AcceptOrganizationInviteCommand request, CancellationToken cancellationToken)
+        {
+            var membership = await OrganizationInviteHelper.GetPendingInviteAsync(
+                _organizationMembershipSearchService, request.UserId, request.OrganizationId);
+
+            await _organizationMembershipService.SetStatusAsync(
+                membership.Id, CustomerModule.Core.ModuleConstants.MembershipStatuses.Approved);
+
+            return await OrganizationInviteHelper.GetContactAggregateAsync(_contactAggregateRepository, _userManagerFactory, request.UserId);
+        }
+    }
+}

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/AcceptOrganizationInviteCommandHandler.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/AcceptOrganizationInviteCommandHandler.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Identity;
 using VirtoCommerce.CustomerModule.Core.Services;
 using VirtoCommerce.Platform.Core.Security;
 using VirtoCommerce.ProfileExperienceApiModule.Data.Aggregates.Contact;
+using CustomerModuleConstants = VirtoCommerce.CustomerModule.Core.ModuleConstants;
 
 namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
 {
@@ -34,7 +35,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
                 _organizationMembershipSearchService, request.UserId, request.OrganizationId);
 
             await _organizationMembershipService.SetStatusAsync(
-                membership.Id, CustomerModule.Core.ModuleConstants.MembershipStatuses.Approved);
+                membership.Id, CustomerModuleConstants.MembershipStatuses.Approved);
 
             return await OrganizationInviteHelper.GetContactAggregateAsync(_contactAggregateRepository, _userManagerFactory, request.UserId);
         }

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/ChangeOrganizationContactRoleCommandHandler.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/ChangeOrganizationContactRoleCommandHandler.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using MediatR;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Options;
+using VirtoCommerce.CustomerModule.Core.Extensions;
 using VirtoCommerce.CustomerModule.Core.Model;
 using VirtoCommerce.CustomerModule.Core.Services;
 using VirtoCommerce.Platform.Core.Security;
@@ -72,7 +73,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
                 return result;
             }
 
-            var membership = await GetMembership(userId, request.OrganizationId);
+            var membership = await _organizationMembershipSearchService.GetMembershipAsync(userId, request.OrganizationId);
             if (membership == null)
             {
                 result.Errors.Add(new IdentityErrorInfo
@@ -130,20 +131,6 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
             }
 
             return roles;
-        }
-
-        protected virtual async Task<OrganizationMembership> GetMembership(string userId, string organizationId)
-        {
-            var searchResult = await _organizationMembershipSearchService.SearchAsync(
-                new OrganizationMembershipSearchCriteria
-                {
-                    UserId = userId,
-                    OrganizationId = organizationId,
-                    Take = 1
-                });
-
-            // At most one membership per (userId, organizationId)
-            return searchResult.Results.FirstOrDefault();
         }
 
         protected virtual IList<OrganizationMembershipRole> BuildMembershipRoles(OrganizationMembership membership, IList<Role> roles)

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/ChangeOrganizationContactRoleCommandHandler.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/ChangeOrganizationContactRoleCommandHandler.cs
@@ -55,7 +55,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
             var contactAggregate = await GetContactAggregate(request.MemberId)
                 ?? throw new InvalidOperationException($"Contact '{request.MemberId}' not found.");
 
-            var userId = GetSecurityAccountId(contactAggregate);
+            var (userId, knownMembership) = await ResolveSecurityAccountAsync(contactAggregate, request.OrganizationId);
             if (string.IsNullOrEmpty(userId))
             {
                 result.Errors.Add(new IdentityErrorInfo { Code = "Forbidden", Description = "It is forbidden to edit this user." });
@@ -73,7 +73,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
                 return result;
             }
 
-            var membership = await _organizationMembershipSearchService.GetMembershipAsync(userId, request.OrganizationId);
+            var membership = knownMembership ?? await _organizationMembershipSearchService.GetMembershipAsync(userId, request.OrganizationId);
             if (membership == null)
             {
                 result.Errors.Add(new IdentityErrorInfo
@@ -95,9 +95,9 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
             return _contactAggregateRepository.GetMemberAggregateRootByIdAsync<ContactAggregate>(memberId);
         }
 
-        protected virtual string GetSecurityAccountId(ContactAggregate contactAggregate)
+        protected virtual Task<(string UserId, OrganizationMembership Membership)> ResolveSecurityAccountAsync(ContactAggregate contactAggregate, string organizationId)
         {
-            return contactAggregate.Contact?.SecurityAccounts?.FirstOrDefault()?.Id;
+            return _organizationMembershipSearchService.ResolveMembershipForOrganizationAsync(contactAggregate.Contact, organizationId);
         }
 
         protected virtual async Task<bool> ValidateUserEditable(string userId, IdentityResultResponse result)

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/ConfirmEmailCommandHandler.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/ConfirmEmailCommandHandler.cs
@@ -62,7 +62,10 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
                 {
                     await userManager.SetLockoutEndDateAsync(user, null);
 
-                    await SendRegistrationNotification(user, cancellationToken);
+                    var contact = await _memberService.GetByIdAsync(user.MemberId) as Contact;
+
+                    await ApproveContactAsync(contact);
+                    await SendRegistrationNotification(user, contact, cancellationToken);
                 }
             }
 
@@ -72,8 +75,22 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
             return result;
         }
 
-        protected virtual async Task SendRegistrationNotification(ApplicationUser user, CancellationToken cancellationToken)
+        protected virtual async Task ApproveContactAsync(Contact contact)
         {
+            if (contact != null && contact.Status == ModuleConstants.ContactStatuses.Locked)
+            {
+                contact.Status = ModuleConstants.ContactStatuses.Approved;
+                await _memberService.SaveChangesAsync([contact]);
+            }
+        }
+
+        protected virtual async Task SendRegistrationNotification(ApplicationUser user, Contact contact, CancellationToken cancellationToken)
+        {
+            if (contact == null)
+            {
+                return;
+            }
+
             var store = await _storeService.GetByIdAsync(user.StoreId);
             if (store == null)
             {
@@ -82,12 +99,6 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
 
             var emailVerificationFlow = store.GetEmailVerificationFlow();
             if (emailVerificationFlow != ModuleConstants.RegistrationFlows.EmailVerificationRequired)
-            {
-                return;
-            }
-
-            var contact = await _memberService.GetByIdAsync(user.MemberId) as Contact;
-            if (contact == null)
             {
                 return;
             }

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/ContactSecurityAccountResolverExtensions.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/ContactSecurityAccountResolverExtensions.cs
@@ -1,0 +1,37 @@
+using System.Linq;
+using System.Threading.Tasks;
+using VirtoCommerce.CustomerModule.Core.Model;
+using VirtoCommerce.CustomerModule.Core.Services;
+using VirtoCommerce.Platform.Core.Common;
+
+namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
+{
+    internal static class ContactSecurityAccountResolverExtensions
+    {
+        public static async Task<(string UserId, OrganizationMembership Membership)> ResolveMembershipForOrganizationAsync(
+            this IOrganizationMembershipSearchService organizationMembershipSearchService,
+            Contact contact,
+            string organizationId)
+        {
+            var securityAccountIds = contact?.SecurityAccounts?
+                .Select(sa => sa.Id)
+                .Where(id => !string.IsNullOrEmpty(id))
+                .ToList() ?? [];
+
+            if (securityAccountIds.Count <= 1)
+            {
+                return (securityAccountIds.FirstOrDefault(), null);
+            }
+
+            var memberships = await organizationMembershipSearchService.SearchAllNoCloneAsync(new OrganizationMembershipSearchCriteria
+            {
+                UserIds = securityAccountIds,
+                OrganizationId = organizationId,
+            });
+
+            var membership = memberships.FirstOrDefault();
+
+            return (membership?.UserId ?? securityAccountIds[0], membership);
+        }
+    }
+}

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/InviteUserCommandHandler.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/InviteUserCommandHandler.cs
@@ -1,241 +1,50 @@
-using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Web;
 using MediatR;
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Identity;
-using Microsoft.Extensions.Hosting;
 using VirtoCommerce.CustomerModule.Core.Model;
 using VirtoCommerce.CustomerModule.Core.Services;
-using VirtoCommerce.NotificationsModule.Core.Extensions;
-using VirtoCommerce.NotificationsModule.Core.Services;
-using VirtoCommerce.NotificationsModule.Core.Types;
-using VirtoCommerce.Platform.Core.Common;
-using VirtoCommerce.Platform.Core.Security;
-using VirtoCommerce.ProfileExperienceApiModule.Data.Extensions;
-using VirtoCommerce.ProfileExperienceApiModule.Data.Models;
 using VirtoCommerce.ProfileExperienceApiModule.Data.Queries;
-using VirtoCommerce.StoreModule.Core.Model;
-using VirtoCommerce.StoreModule.Core.Services;
 
 namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
 {
     public class InviteUserCommandHandler : IRequestHandler<InviteUserCommand, IdentityResultResponse>
     {
-        private const string _userType = "Customer";
+        private readonly IInviteCustomerService _inviteCustomerService;
 
-        private readonly IWebHostEnvironment _environment;
-        private readonly Func<UserManager<ApplicationUser>> _userManagerFactory;
-        private readonly Func<RoleManager<Role>> _roleManagerFactory;
-        private readonly IMemberService _memberService;
-        private readonly INotificationSearchService _notificationSearchService;
-        private readonly INotificationSender _notificationSender;
-        private readonly IStoreService _storeService;
-        private readonly IOrganizationMembershipService _organizationMembershipService;
-
-        public InviteUserCommandHandler(
-            IWebHostEnvironment environment,
-            Func<UserManager<ApplicationUser>> userManager,
-            IMemberService memberService,
-            INotificationSearchService notificationSearchService,
-            INotificationSender notificationSender,
-            IStoreService storeService,
-            Func<RoleManager<Role>> roleManagerFactory,
-            IOrganizationMembershipService organizationMembershipService)
+        public InviteUserCommandHandler(IInviteCustomerService inviteCustomerService)
         {
-            _environment = environment;
-            _userManagerFactory = userManager;
-            _memberService = memberService;
-            _notificationSearchService = notificationSearchService;
-            _notificationSender = notificationSender;
-            _storeService = storeService;
-            _roleManagerFactory = roleManagerFactory;
-            _organizationMembershipService = organizationMembershipService;
+            _inviteCustomerService = inviteCustomerService;
         }
 
         public virtual async Task<IdentityResultResponse> Handle(InviteUserCommand request, CancellationToken cancellationToken)
         {
-            var result = new IdentityResultResponse
-            {
-                Errors = new List<IdentityErrorInfo>(),
-                Succeeded = false,
-            };
+            var inviteRequest = ToInviteCustomerRequest(request);
 
-            // PT-6083: reduce complexity
-            foreach (var email in request.Emails.Distinct())
-            {
-                using var userManager = _userManagerFactory();
+            var inviteResult = await _inviteCustomerService.InviteCustomerAsyc(inviteRequest, cancellationToken);
 
-                var contact = CreateContact(request, email);
-
-                await _memberService.SaveChangesAsync(new Member[] { contact });
-
-                var user = CreateUser(request, contact, email);
-                var identityResult = await userManager.CreateAsync(user);
-
-                if (identityResult.Succeeded)
-                {
-                    var store = await _storeService.GetByIdAsync(user.StoreId);
-                    if (store == null)
-                    {
-                        var errors = _environment.IsDevelopment() ? new[] { new IdentityError { Code = "StoreNotFound", Description = "Store not found" } } : null;
-                        identityResult = IdentityResult.Failed(errors);
-                    }
-                    else
-                    {
-                        if (string.IsNullOrEmpty(store.Url) || string.IsNullOrEmpty(store.Email))
-                        {
-                            var errors = _environment.IsDevelopment() ? new[] { new IdentityError { Code = "StoreNotConfigured", Description = "Store has invalid URL or email" } } : null;
-                            identityResult = IdentityResult.Failed(errors);
-                        }
-                        else
-                        {
-                            result.Errors.AddRange(await AssignUserRoles(user, request.RoleIds, request.OrganizationId));
-                            await SendNotificationAsync(request, store, email);
-                        }
-                    }
-                }
-
-                result.Errors.AddRange(identityResult.Errors.Select(x => x.MapToIdentityErrorInfo()));
-                result.Succeeded |= identityResult.Succeeded;
-
-                if (!identityResult.Succeeded)
-                {
-                    await _memberService.DeleteAsync(new[] { contact.Id });
-
-                    if (user.Id != null)
-                    {
-                        await userManager.DeleteAsync(user);
-                    }
-                }
-            }
-
-            return result;
+            return OrganizationInviteHelper.ToIdentityResultResponse(inviteResult);
         }
 
-        protected virtual Contact CreateContact(InviteUserCommand request, string email)
+        protected virtual InviteCustomerRequest ToInviteCustomerRequest(InviteUserCommand request)
         {
-            var contact = AbstractTypeFactory<Contact>.TryCreateInstance();
-            contact.Status = ModuleConstants.ContactStatuses.Invited;
-            contact.FirstName = string.Empty;
-            contact.LastName = string.Empty;
-            contact.FullName = string.Empty;
-            contact.Emails = new List<string> { email };
-
-            if (!string.IsNullOrEmpty(request.OrganizationId))
-            {
-                contact.Organizations = new List<string> { request.OrganizationId };
-            }
-
-            return contact;
-        }
-
-        protected virtual ApplicationUser CreateUser(InviteUserCommand request, Contact contact, string email)
-        {
-            var user = AbstractTypeFactory<ApplicationUser>.TryCreateInstance();
-
-            user.UserName = email;
-            user.Email = email;
-            user.MemberId = contact.Id;
-            user.StoreId = request.StoreId;
-            user.UserType = _userType;
-            user.LockoutEnd = DateTimeOffset.MaxValue;
-
-            return user;
-        }
-
-        [Obsolete("Use AssignUserRoles(user, roleIds, organizationId) instead.", DiagnosticId = "VC0014")]
-        protected virtual Task<List<IdentityErrorInfo>> AssignUserRoles(ApplicationUser user, string[] roleIds)
-            => AssignUserRoles(user, roleIds, organizationId: null);
-
-        protected virtual async Task<List<IdentityErrorInfo>> AssignUserRoles(ApplicationUser user, string[] roleIds, string organizationId)
-        {
-            var errors = new List<IdentityErrorInfo>();
-
-            if (roleIds.IsNullOrEmpty())
-            {
-                return errors;
-            }
-
-            using var roleManager = _roleManagerFactory();
-
-            var roles = new List<Role>();
-            foreach (var roleId in roleIds)
-            {
-                var role = await roleManager.FindByIdAsync(roleId) ?? await roleManager.FindByNameAsync(roleId);
-                if (role != null)
-                {
-                    roles.Add(role);
-                }
-                else
-                {
-                    errors.Add(new IdentityErrorInfo { Code = "Role not found", Description = $"Role '{roleId}' not found", Parameter = roleId });
-                }
-            }
-
-            if (errors.Count > 0)
-            {
-                return errors;
-            }
-
-            if (!string.IsNullOrEmpty(organizationId))
-            {
-                var membership = new OrganizationMembership
-                {
-                    UserId = user.Id,
-                    OrganizationId = organizationId,
-                    Roles = roles
-                        .Select(r => new OrganizationMembershipRole
-                        {
-                            RoleId = r.Id,
-                            RoleName = r.Name,
-                        })
-                        .ToList(),
-                };
-                await _organizationMembershipService.SaveChangesAsync([membership]);
-            }
-            else
-            {
-                using var userManager = _userManagerFactory();
-                var assignResult = await userManager.AddToRolesAsync(user, roles.Select(x => x.NormalizedName).ToArray());
-                errors.AddRange(assignResult.Errors.Select(x => x.MapToIdentityErrorInfo()));
-            }
-
-            return errors;
-        }
-
-        protected virtual async Task SendNotificationAsync(InviteUserCommand request, Store store, string email)
-        {
-            using var userManager = _userManagerFactory();
-
-            var user = await userManager.FindByEmailAsync(email);
-            if (user == null)
-            {
-                return;
-            }
-
-            var token = await userManager.GeneratePasswordResetTokenAsync(user);
-
-            // take notification
-            RegistrationInvitationNotificationBase notification = !string.IsNullOrEmpty(request.OrganizationId)
-                ? await _notificationSearchService.GetNotificationAsync<RegistrationInvitationEmailNotification>(new TenantIdentity(store.Id, nameof(Store)))
-                : await _notificationSearchService.GetNotificationAsync<RegistrationInvitationCustomerEmailNotification>(new TenantIdentity(store.Id, nameof(Store)));
-
-            notification.InviteUrl = $"{store.Url.TrimLastSlash()}{request.UrlSuffix.NormalizeUrlSuffix()}?userId={user.Id}&email={HttpUtility.UrlEncode(user.Email)}&token={Uri.EscapeDataString(token)}";
+            var additionalParameters = new Dictionary<string, string>();
 
             if (!string.IsNullOrEmpty(request.CustomerOrderId))
             {
-                notification.InviteUrl = $"{notification.InviteUrl}&customerOrderId={request.CustomerOrderId}";
+                additionalParameters["customerOrderId"] = request.CustomerOrderId;
             }
 
-            notification.Message = request.Message;
-            notification.To = user.Email;
-            notification.From = store.Email;
-
-            await _notificationSender.ScheduleSendNotificationAsync(notification);
+            return new InviteCustomerRequest
+            {
+                StoreId = request.StoreId,
+                OrganizationId = request.OrganizationId,
+                UrlSuffix = request.UrlSuffix,
+                Emails = request.Emails,
+                Message = request.Message,
+                RoleIds = request.RoleIds,
+                AdditionalParameters = additionalParameters,
+            };
         }
     }
 }

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/LockOrganizationContactCommandHandler.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/LockOrganizationContactCommandHandler.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using MediatR;
@@ -37,7 +36,9 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
             var contactAggregate = await _contactAggregateRepository.GetMemberAggregateRootByIdAsync<ContactAggregate>(request.MemberId)
                 ?? throw new InvalidOperationException($"Contact '{request.MemberId}' not found.");
 
-            var userId = contactAggregate.Contact?.SecurityAccounts?.FirstOrDefault()?.Id;
+            var (userId, _) = await _organizationMembershipSearchService.ResolveMembershipForOrganizationAsync(
+                contactAggregate.Contact, request.OrganizationId);
+
             if (string.IsNullOrEmpty(userId))
             {
                 return contactAggregate;

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/OrganizationInviteHelper.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/OrganizationInviteHelper.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Identity;
+using VirtoCommerce.CustomerModule.Core.Extensions;
+using VirtoCommerce.CustomerModule.Core.Model;
+using VirtoCommerce.CustomerModule.Core.Services;
+using VirtoCommerce.Platform.Core.Security;
+using VirtoCommerce.ProfileExperienceApiModule.Data.Aggregates.Contact;
+using VirtoCommerce.ProfileExperienceApiModule.Data.Models;
+using VirtoCommerce.ProfileExperienceApiModule.Data.Queries;
+
+namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
+{
+    internal static class OrganizationInviteHelper
+    {
+        public static async Task<OrganizationMembership> GetPendingInviteAsync(
+            IOrganizationMembershipSearchService organizationMembershipSearchService,
+            string userId,
+            string organizationId)
+        {
+            if (string.IsNullOrEmpty(userId) || string.IsNullOrEmpty(organizationId))
+            {
+                throw new InvalidOperationException("UserId and OrganizationId are required.");
+            }
+
+            var membership = await organizationMembershipSearchService.GetMembershipAsync(userId, organizationId);
+            if (membership == null || membership.Status != VirtoCommerce.CustomerModule.Core.ModuleConstants.MembershipStatuses.Invited)
+            {
+                throw new InvalidOperationException($"No pending invite found for organization '{organizationId}'.");
+            }
+
+            return membership;
+        }
+
+        public static async Task<ContactAggregate> GetContactAggregateAsync(
+            IContactAggregateRepository contactAggregateRepository,
+            Func<UserManager<ApplicationUser>> userManagerFactory,
+            string userId)
+        {
+            using var userManager = userManagerFactory();
+
+            var user = await userManager.FindByIdAsync(userId)
+                ?? throw new InvalidOperationException($"User '{userId}' not found.");
+
+            return await contactAggregateRepository.GetMemberAggregateRootByIdAsync<ContactAggregate>(user.MemberId);
+        }
+
+        public static IdentityResultResponse ToIdentityResultResponse(InviteCustomerResult inviteResult)
+        {
+            return new IdentityResultResponse
+            {
+                Succeeded = inviteResult.Succeeded,
+                Errors = (inviteResult.Errors ?? new List<InviteCustomerError>())
+                    .Select(error => new IdentityErrorInfo
+                    {
+                        Code = error.Code,
+                        Description = error.Description,
+                        Parameter = error.Parameter,
+                    })
+                    .ToList(),
+            };
+        }
+    }
+}

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/OrganizationInviteHelper.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/OrganizationInviteHelper.cs
@@ -10,6 +10,7 @@ using VirtoCommerce.Platform.Core.Security;
 using VirtoCommerce.ProfileExperienceApiModule.Data.Aggregates.Contact;
 using VirtoCommerce.ProfileExperienceApiModule.Data.Models;
 using VirtoCommerce.ProfileExperienceApiModule.Data.Queries;
+using CustomerModuleConstants = VirtoCommerce.CustomerModule.Core.ModuleConstants;
 
 namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
 {
@@ -18,15 +19,16 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
         public static async Task<OrganizationMembership> GetPendingInviteAsync(
             IOrganizationMembershipSearchService organizationMembershipSearchService,
             string userId,
-            string organizationId)
+            string organizationId,
+            OrganizationMembership knownMembership = null)
         {
             if (string.IsNullOrEmpty(userId) || string.IsNullOrEmpty(organizationId))
             {
                 throw new InvalidOperationException("UserId and OrganizationId are required.");
             }
 
-            var membership = await organizationMembershipSearchService.GetMembershipAsync(userId, organizationId);
-            if (membership == null || membership.Status != VirtoCommerce.CustomerModule.Core.ModuleConstants.MembershipStatuses.Invited)
+            var membership = knownMembership ?? await organizationMembershipSearchService.GetMembershipAsync(userId, organizationId);
+            if (membership == null || membership.Status != CustomerModuleConstants.MembershipStatuses.Invited)
             {
                 throw new InvalidOperationException($"No pending invite found for organization '{organizationId}'.");
             }

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/RegisterByInvitationCommand.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/RegisterByInvitationCommand.cs
@@ -1,5 +1,5 @@
-using VirtoCommerce.Xapi.Core.Infrastructure;
 using VirtoCommerce.ProfileExperienceApiModule.Data.Queries;
+using VirtoCommerce.Xapi.Core.Infrastructure;
 
 namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
 {
@@ -20,5 +20,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
         public string Password { get; set; }
 
         public string CustomerOrderId { get; set; }
+
+        public string OrganizationId { get; set; }
     }
 }

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/RegisterByInvitationCommandHandler.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/RegisterByInvitationCommandHandler.cs
@@ -27,6 +27,8 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
         private readonly IMediator _mediator;
         private readonly Func<UserManager<ApplicationUser>> _userManagerFactory;
         private readonly RegisterByInvitationCommandValidator _validator;
+        private readonly IOrganizationMembershipService _organizationMembershipService;
+        private readonly IOrganizationMembershipSearchService _organizationMembershipSearchService;
 
         public RegisterByInvitationCommandHandler(
             IWebHostEnvironment environment,
@@ -34,7 +36,9 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
             IMemberService memberService,
             IStoreService storeService,
             IMediator mediator,
-            RegisterByInvitationCommandValidator validator)
+            RegisterByInvitationCommandValidator validator,
+            IOrganizationMembershipService organizationMembershipService,
+            IOrganizationMembershipSearchService organizationMembershipSearchService)
         {
             _environment = environment;
             _userManagerFactory = userManager;
@@ -42,6 +46,8 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
             _storeService = storeService;
             _mediator = mediator;
             _validator = validator;
+            _organizationMembershipService = organizationMembershipService;
+            _organizationMembershipSearchService = organizationMembershipSearchService;
         }
 
         public virtual async Task<IdentityResultResponse> Handle(RegisterByInvitationCommand request, CancellationToken cancellationToken)
@@ -108,6 +114,8 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
 
             await _memberService.SaveChangesAsync([contact]);
 
+            await ApproveInvitedMembershipsAsync(user.Id, request.OrganizationId, contact.Organizations);
+
             // associate order
             if (!string.IsNullOrEmpty(request.CustomerOrderId))
             {
@@ -117,6 +125,31 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
             await SendRegistrationNotificationAsync(user, contact, cancellationToken);
 
             return SetResponse(identityResult);
+        }
+
+        protected virtual async Task ApproveInvitedMembershipsAsync(string userId, string organizationId, IList<string> contactOrganizationIds)
+        {
+            var organizationIds = !string.IsNullOrEmpty(organizationId)
+                ? [organizationId]
+                : contactOrganizationIds;
+
+            if (organizationIds.IsNullOrEmpty())
+            {
+                return;
+            }
+
+            var invitedMemberships = await _organizationMembershipSearchService.SearchAllNoCloneAsync(new OrganizationMembershipSearchCriteria
+            {
+                UserId = userId,
+                OrganizationIds = organizationIds,
+                Statuses = [CustomerModule.Core.ModuleConstants.MembershipStatuses.Invited],
+            });
+
+            foreach (var membership in invitedMemberships)
+            {
+                await _organizationMembershipService.SetStatusAsync(
+                    membership.Id, CustomerModule.Core.ModuleConstants.MembershipStatuses.Approved);
+            }
         }
 
         protected virtual void UpdateContact(Contact contact, RegisterByInvitationCommand request)

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/RegisterByInvitationCommandHandler.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/RegisterByInvitationCommandHandler.cs
@@ -16,6 +16,7 @@ using VirtoCommerce.ProfileExperienceApiModule.Data.Queries;
 using VirtoCommerce.ProfileExperienceApiModule.Data.Validators;
 using VirtoCommerce.StoreModule.Core.Services;
 using VirtoCommerce.XOrder.Core.Commands;
+using CustomerModuleConstants = VirtoCommerce.CustomerModule.Core.ModuleConstants;
 
 namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
 {
@@ -142,14 +143,20 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
             {
                 UserId = userId,
                 OrganizationIds = organizationIds,
-                Statuses = [CustomerModule.Core.ModuleConstants.MembershipStatuses.Invited],
+                Statuses = [CustomerModuleConstants.MembershipStatuses.Invited],
             });
+
+            if (invitedMemberships.Count == 0)
+            {
+                return;
+            }
 
             foreach (var membership in invitedMemberships)
             {
-                await _organizationMembershipService.SetStatusAsync(
-                    membership.Id, CustomerModule.Core.ModuleConstants.MembershipStatuses.Approved);
+                membership.Status = CustomerModuleConstants.MembershipStatuses.Approved;
             }
+
+            await _organizationMembershipService.SaveChangesAsync(invitedMemberships);
         }
 
         protected virtual void UpdateContact(Contact contact, RegisterByInvitationCommand request)

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/RegisterRequestCommandHandler.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/RegisterRequestCommandHandler.cs
@@ -25,6 +25,7 @@ using VirtoCommerce.StoreModule.Core.Model;
 using VirtoCommerce.StoreModule.Core.Services;
 using VirtoCommerce.Xapi.Core.Models;
 using VirtoCommerce.Xapi.Core.Services;
+using CustomerModuleConstants = VirtoCommerce.CustomerModule.Core.ModuleConstants;
 using CustomerSettings = VirtoCommerce.CustomerModule.Core.ModuleConstants.Settings.General;
 
 namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
@@ -240,6 +241,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
             {
                 UserId = account.Id,
                 OrganizationId = organizationId,
+                Status = CustomerModuleConstants.MembershipStatuses.Approved,
                 Roles =
                 [
                     new OrganizationMembershipRole

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/RejectOrganizationInviteCommand.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/RejectOrganizationInviteCommand.cs
@@ -1,0 +1,12 @@
+using VirtoCommerce.ProfileExperienceApiModule.Data.Aggregates.Contact;
+using VirtoCommerce.Xapi.Core.Infrastructure;
+
+namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
+{
+    public class RejectOrganizationInviteCommand : ICommand<ContactAggregate>
+    {
+        public string UserId { get; set; }
+
+        public string OrganizationId { get; set; }
+    }
+}

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/RejectOrganizationInviteCommandHandler.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/RejectOrganizationInviteCommandHandler.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using Microsoft.AspNetCore.Identity;
+using VirtoCommerce.CustomerModule.Core.Services;
+using VirtoCommerce.Platform.Core.Security;
+using VirtoCommerce.ProfileExperienceApiModule.Data.Aggregates.Contact;
+
+namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
+{
+    public class RejectOrganizationInviteCommandHandler : IRequestHandler<RejectOrganizationInviteCommand, ContactAggregate>
+    {
+        private readonly IContactAggregateRepository _contactAggregateRepository;
+        private readonly IOrganizationMembershipService _organizationMembershipService;
+        private readonly IOrganizationMembershipSearchService _organizationMembershipSearchService;
+        private readonly Func<UserManager<ApplicationUser>> _userManagerFactory;
+
+        public RejectOrganizationInviteCommandHandler(
+            IContactAggregateRepository contactAggregateRepository,
+            IOrganizationMembershipService organizationMembershipService,
+            IOrganizationMembershipSearchService organizationMembershipSearchService,
+            Func<UserManager<ApplicationUser>> userManagerFactory)
+        {
+            _contactAggregateRepository = contactAggregateRepository;
+            _organizationMembershipService = organizationMembershipService;
+            _organizationMembershipSearchService = organizationMembershipSearchService;
+            _userManagerFactory = userManagerFactory;
+        }
+
+        public virtual async Task<ContactAggregate> Handle(RejectOrganizationInviteCommand request, CancellationToken cancellationToken)
+        {
+            var membership = await OrganizationInviteHelper.GetPendingInviteAsync(
+                _organizationMembershipSearchService, request.UserId, request.OrganizationId);
+
+            await _organizationMembershipService.SetStatusAsync(
+                membership.Id, CustomerModule.Core.ModuleConstants.MembershipStatuses.Rejected);
+
+            return await OrganizationInviteHelper.GetContactAggregateAsync(_contactAggregateRepository, _userManagerFactory, request.UserId);
+        }
+    }
+}

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/RejectOrganizationInviteCommandHandler.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/RejectOrganizationInviteCommandHandler.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Identity;
 using VirtoCommerce.CustomerModule.Core.Services;
 using VirtoCommerce.Platform.Core.Security;
 using VirtoCommerce.ProfileExperienceApiModule.Data.Aggregates.Contact;
+using CustomerModuleConstants = VirtoCommerce.CustomerModule.Core.ModuleConstants;
 
 namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
 {
@@ -34,7 +35,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
                 _organizationMembershipSearchService, request.UserId, request.OrganizationId);
 
             await _organizationMembershipService.SetStatusAsync(
-                membership.Id, CustomerModule.Core.ModuleConstants.MembershipStatuses.Rejected);
+                membership.Id, CustomerModuleConstants.MembershipStatuses.Rejected);
 
             return await OrganizationInviteHelper.GetContactAggregateAsync(_contactAggregateRepository, _userManagerFactory, request.UserId);
         }

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/RejectOrganizationInviteCommandHandler.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/RejectOrganizationInviteCommandHandler.cs
@@ -37,7 +37,12 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
             await _organizationMembershipService.SetStatusAsync(
                 membership.Id, CustomerModuleConstants.MembershipStatuses.Rejected);
 
-            return await OrganizationInviteHelper.GetContactAggregateAsync(_contactAggregateRepository, _userManagerFactory, request.UserId);
+            var contactAggregate = await OrganizationInviteHelper.GetContactAggregateAsync(_contactAggregateRepository, _userManagerFactory, request.UserId);
+            contactAggregate.Contact.Organizations?.Remove(request.OrganizationId);
+
+            await _contactAggregateRepository.SaveAsync(contactAggregate);
+
+            return contactAggregate;
         }
     }
 }

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/RejectOrganizationInviteCommandHandler.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/RejectOrganizationInviteCommandHandler.cs
@@ -38,9 +38,6 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
                 membership.Id, CustomerModuleConstants.MembershipStatuses.Rejected);
 
             var contactAggregate = await OrganizationInviteHelper.GetContactAggregateAsync(_contactAggregateRepository, _userManagerFactory, request.UserId);
-            contactAggregate.Contact.Organizations?.Remove(request.OrganizationId);
-
-            await _contactAggregateRepository.SaveAsync(contactAggregate);
 
             return contactAggregate;
         }

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/RemoveMemberFromOrganizationCommandHandler.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/RemoveMemberFromOrganizationCommandHandler.cs
@@ -1,6 +1,9 @@
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using MediatR;
+using VirtoCommerce.CustomerModule.Core.Extensions;
+using VirtoCommerce.CustomerModule.Core.Services;
 using VirtoCommerce.ProfileExperienceApiModule.Data.Aggregates.Contact;
 
 namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
@@ -8,21 +11,44 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
     public class RemoveMemberFromOrganizationCommandHandler : IRequestHandler<RemoveMemberFromOrganizationCommand, ContactAggregate>
     {
         private readonly IContactAggregateRepository _contactAggregateRepository;
+        private readonly IOrganizationMembershipService _organizationMembershipService;
+        private readonly IOrganizationMembershipSearchService _organizationMembershipSearchService;
 
         public RemoveMemberFromOrganizationCommandHandler(
-            IContactAggregateRepository contactAggregateRepository
-            )
+            IContactAggregateRepository contactAggregateRepository,
+            IOrganizationMembershipService organizationMembershipService,
+            IOrganizationMembershipSearchService organizationMembershipSearchService)
         {
             _contactAggregateRepository = contactAggregateRepository;
+            _organizationMembershipService = organizationMembershipService;
+            _organizationMembershipSearchService = organizationMembershipSearchService;
         }
 
         public async Task<ContactAggregate> Handle(RemoveMemberFromOrganizationCommand request, CancellationToken cancellationToken)
         {
             var contactAggregate = await _contactAggregateRepository.GetMemberAggregateRootByIdAsync<ContactAggregate>(request.ContactId);
-            contactAggregate.Contact.Organizations.Remove(request.OrganizationId);
+            contactAggregate.Contact.Organizations?.Remove(request.OrganizationId);
             await _contactAggregateRepository.SaveAsync(contactAggregate);
 
+            await RemoveMembershipAsync(contactAggregate, request.OrganizationId);
+
             return contactAggregate;
+        }
+
+        private async Task RemoveMembershipAsync(ContactAggregate contactAggregate, string organizationId)
+        {
+            var userId = contactAggregate.Contact?.SecurityAccounts?.FirstOrDefault()?.Id;
+            if (string.IsNullOrEmpty(userId))
+            {
+                return;
+            }
+
+            var membership = await _organizationMembershipSearchService.GetMembershipAsync(userId, organizationId);
+
+            if (membership != null)
+            {
+                await _organizationMembershipService.DeleteAsync([membership.Id]);
+            }
         }
     }
 }

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/RemoveMemberFromOrganizationCommandHandler.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/RemoveMemberFromOrganizationCommandHandler.cs
@@ -1,4 +1,3 @@
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using MediatR;
@@ -37,13 +36,15 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
 
         private async Task RemoveMembershipAsync(ContactAggregate contactAggregate, string organizationId)
         {
-            var userId = contactAggregate.Contact?.SecurityAccounts?.FirstOrDefault()?.Id;
+            var (userId, membership) = await _organizationMembershipSearchService.ResolveMembershipForOrganizationAsync(
+                contactAggregate.Contact, organizationId);
+
             if (string.IsNullOrEmpty(userId))
             {
                 return;
             }
 
-            var membership = await _organizationMembershipSearchService.GetMembershipAsync(userId, organizationId);
+            membership ??= await _organizationMembershipSearchService.GetMembershipAsync(userId, organizationId);
 
             if (membership != null)
             {

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/RemoveMemberFromOrganizationCommandHandler.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/RemoveMemberFromOrganizationCommandHandler.cs
@@ -4,6 +4,7 @@ using MediatR;
 using VirtoCommerce.CustomerModule.Core.Extensions;
 using VirtoCommerce.CustomerModule.Core.Services;
 using VirtoCommerce.ProfileExperienceApiModule.Data.Aggregates.Contact;
+using CustomerModuleConstants = VirtoCommerce.CustomerModule.Core.ModuleConstants;
 
 namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
 {
@@ -48,7 +49,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
 
             if (membership != null)
             {
-                await _organizationMembershipService.DeleteAsync([membership.Id]);
+                await _organizationMembershipService.SetStatusAsync(membership.Id, CustomerModuleConstants.MembershipStatuses.Deleted);
             }
         }
     }

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/RemoveMemberFromOrganizationCommandHandler.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/RemoveMemberFromOrganizationCommandHandler.cs
@@ -27,8 +27,6 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
         public async Task<ContactAggregate> Handle(RemoveMemberFromOrganizationCommand request, CancellationToken cancellationToken)
         {
             var contactAggregate = await _contactAggregateRepository.GetMemberAggregateRootByIdAsync<ContactAggregate>(request.ContactId);
-            contactAggregate.Contact.Organizations?.Remove(request.OrganizationId);
-            await _contactAggregateRepository.SaveAsync(contactAggregate);
 
             await RemoveMembershipAsync(contactAggregate, request.OrganizationId);
 

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/ResendOrganizationInviteCommand.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/ResendOrganizationInviteCommand.cs
@@ -1,0 +1,16 @@
+using VirtoCommerce.ProfileExperienceApiModule.Data.Queries;
+using VirtoCommerce.Xapi.Core.Infrastructure;
+
+namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
+{
+    public class ResendOrganizationInviteCommand : ICommand<IdentityResultResponse>
+    {
+        public string MemberId { get; set; }
+
+        public string OrganizationId { get; set; }
+
+        public string UrlSuffix { get; set; }
+
+        public string Message { get; set; }
+    }
+}

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/ResendOrganizationInviteCommandHandler.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/ResendOrganizationInviteCommandHandler.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using VirtoCommerce.CustomerModule.Core.Services;
+using VirtoCommerce.ProfileExperienceApiModule.Data.Aggregates.Contact;
+using VirtoCommerce.ProfileExperienceApiModule.Data.Models;
+using VirtoCommerce.ProfileExperienceApiModule.Data.Queries;
+
+namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
+{
+    public class ResendOrganizationInviteCommandHandler : IRequestHandler<ResendOrganizationInviteCommand, IdentityResultResponse>
+    {
+        private readonly IContactAggregateRepository _contactAggregateRepository;
+        private readonly IOrganizationMembershipSearchService _organizationMembershipSearchService;
+        private readonly IInviteCustomerService _inviteCustomerService;
+
+        public ResendOrganizationInviteCommandHandler(
+            IContactAggregateRepository contactAggregateRepository,
+            IOrganizationMembershipSearchService organizationMembershipSearchService,
+            IInviteCustomerService inviteCustomerService)
+        {
+            _contactAggregateRepository = contactAggregateRepository;
+            _organizationMembershipSearchService = organizationMembershipSearchService;
+            _inviteCustomerService = inviteCustomerService;
+        }
+
+        public virtual async Task<IdentityResultResponse> Handle(ResendOrganizationInviteCommand request, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrEmpty(request.OrganizationId))
+            {
+                throw new InvalidOperationException("OrganizationId is required for resending an organization invite.");
+            }
+
+            var contactAggregate = await _contactAggregateRepository.GetMemberAggregateRootByIdAsync<ContactAggregate>(request.MemberId);
+            var userId = contactAggregate?.Contact?.SecurityAccounts?.FirstOrDefault()?.Id;
+            if (string.IsNullOrEmpty(userId))
+            {
+                return new IdentityResultResponse
+                {
+                    Succeeded = false,
+                    Errors = [new IdentityErrorInfo { Code = "UserNotFound", Description = "Invited user not found" }],
+                };
+            }
+
+            var membership = await OrganizationInviteHelper.GetPendingInviteAsync(
+                _organizationMembershipSearchService, userId, request.OrganizationId);
+
+            var resendResult = await _inviteCustomerService.ResendInviteAsync(
+                membership.Id, request.UrlSuffix, request.Message, cancellationToken);
+
+            return OrganizationInviteHelper.ToIdentityResultResponse(resendResult);
+        }
+    }
+}

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/ResendOrganizationInviteCommandHandler.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/ResendOrganizationInviteCommandHandler.cs
@@ -1,12 +1,13 @@
-using System;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using MediatR;
+using VirtoCommerce.CustomerModule.Core.Extensions;
+using VirtoCommerce.CustomerModule.Core.Model;
 using VirtoCommerce.CustomerModule.Core.Services;
 using VirtoCommerce.ProfileExperienceApiModule.Data.Aggregates.Contact;
 using VirtoCommerce.ProfileExperienceApiModule.Data.Models;
 using VirtoCommerce.ProfileExperienceApiModule.Data.Queries;
+using CustomerModuleConstants = VirtoCommerce.CustomerModule.Core.ModuleConstants;
 
 namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
 {
@@ -30,11 +31,17 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
         {
             if (string.IsNullOrEmpty(request.OrganizationId))
             {
-                throw new InvalidOperationException("OrganizationId is required for resending an organization invite.");
+                return new IdentityResultResponse
+                {
+                    Succeeded = false,
+                    Errors = [new IdentityErrorInfo { Code = "OrganizationIdRequired", Description = "OrganizationId is required for resending an organization invite." }],
+                };
             }
 
             var contactAggregate = await _contactAggregateRepository.GetMemberAggregateRootByIdAsync<ContactAggregate>(request.MemberId);
-            var userId = contactAggregate?.Contact?.SecurityAccounts?.FirstOrDefault()?.Id;
+            var (userId, knownMembership) = await _organizationMembershipSearchService.ResolveMembershipForOrganizationAsync(
+                contactAggregate?.Contact, request.OrganizationId);
+
             if (string.IsNullOrEmpty(userId))
             {
                 return new IdentityResultResponse
@@ -44,11 +51,19 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
                 };
             }
 
-            var membership = await OrganizationInviteHelper.GetPendingInviteAsync(
-                _organizationMembershipSearchService, userId, request.OrganizationId);
+            var membership = knownMembership ?? await _organizationMembershipSearchService.GetMembershipAsync(userId, request.OrganizationId);
+            if (membership == null || membership.Status != CustomerModuleConstants.MembershipStatuses.Invited)
+            {
+                return new IdentityResultResponse
+                {
+                    Succeeded = false,
+                    Errors = [new IdentityErrorInfo { Code = "InviteNotFound", Description = $"No pending invite found for organization '{request.OrganizationId}'." }],
+                };
+            }
 
             var resendResult = await _inviteCustomerService.ResendInviteAsync(
-                membership.Id, request.UrlSuffix, request.Message, cancellationToken);
+                new ResendInviteRequest { MembershipId = membership.Id, UrlSuffix = request.UrlSuffix, Message = request.Message },
+                cancellationToken);
 
             return OrganizationInviteHelper.ToIdentityResultResponse(resendResult);
         }

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/RevokeOrganizationInviteCommand.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/RevokeOrganizationInviteCommand.cs
@@ -1,0 +1,12 @@
+using VirtoCommerce.ProfileExperienceApiModule.Data.Aggregates.Contact;
+using VirtoCommerce.Xapi.Core.Infrastructure;
+
+namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
+{
+    public class RevokeOrganizationInviteCommand : ICommand<ContactAggregate>
+    {
+        public string MemberId { get; set; }
+
+        public string OrganizationId { get; set; }
+    }
+}

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/RevokeOrganizationInviteCommandHandler.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/RevokeOrganizationInviteCommandHandler.cs
@@ -3,33 +3,32 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using MediatR;
-using VirtoCommerce.CustomerModule.Core.Extensions;
 using VirtoCommerce.CustomerModule.Core.Services;
 using VirtoCommerce.ProfileExperienceApiModule.Data.Aggregates.Contact;
 
 namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
 {
-    public class LockOrganizationContactCommandHandler : IRequestHandler<LockOrganizationContactCommand, ContactAggregate>
+    public class RevokeOrganizationInviteCommandHandler : IRequestHandler<RevokeOrganizationInviteCommand, ContactAggregate>
     {
         private readonly IContactAggregateRepository _contactAggregateRepository;
-        private readonly IOrganizationMembershipService _organizationMembershipService;
         private readonly IOrganizationMembershipSearchService _organizationMembershipSearchService;
+        private readonly IInviteCustomerService _inviteCustomerService;
 
-        public LockOrganizationContactCommandHandler(
+        public RevokeOrganizationInviteCommandHandler(
             IContactAggregateRepository contactAggregateRepository,
-            IOrganizationMembershipService organizationMembershipService,
-            IOrganizationMembershipSearchService organizationMembershipSearchService)
+            IOrganizationMembershipSearchService organizationMembershipSearchService,
+            IInviteCustomerService inviteCustomerService)
         {
             _contactAggregateRepository = contactAggregateRepository;
-            _organizationMembershipService = organizationMembershipService;
             _organizationMembershipSearchService = organizationMembershipSearchService;
+            _inviteCustomerService = inviteCustomerService;
         }
 
-        public virtual async Task<ContactAggregate> Handle(LockOrganizationContactCommand request, CancellationToken cancellationToken)
+        public virtual async Task<ContactAggregate> Handle(RevokeOrganizationInviteCommand request, CancellationToken cancellationToken)
         {
             if (string.IsNullOrEmpty(request.OrganizationId))
             {
-                throw new InvalidOperationException("OrganizationId is required for organization-scoped lock.");
+                throw new InvalidOperationException("OrganizationId is required for revoking an organization invite.");
             }
 
             var contactAggregate = await _contactAggregateRepository.GetMemberAggregateRootByIdAsync<ContactAggregate>(request.MemberId)
@@ -41,12 +40,12 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
                 return contactAggregate;
             }
 
-            var membership = await _organizationMembershipSearchService.GetMembershipAsync(userId, request.OrganizationId)
-                ?? throw new InvalidOperationException($"Contact '{request.MemberId}' has no membership in organization '{request.OrganizationId}'.");
+            var membership = await OrganizationInviteHelper.GetPendingInviteAsync(
+                _organizationMembershipSearchService, userId, request.OrganizationId);
 
-            await _organizationMembershipService.LockAsync(membership.Id);
+            await _inviteCustomerService.RevokeInviteAsync(membership.Id, cancellationToken);
 
-            return contactAggregate;
+            return await _contactAggregateRepository.GetMemberAggregateRootByIdAsync<ContactAggregate>(request.MemberId);
         }
     }
 }

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/RevokeOrganizationInviteCommandHandler.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/RevokeOrganizationInviteCommandHandler.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using MediatR;
@@ -34,14 +33,16 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
             var contactAggregate = await _contactAggregateRepository.GetMemberAggregateRootByIdAsync<ContactAggregate>(request.MemberId)
                 ?? throw new InvalidOperationException($"Contact '{request.MemberId}' not found.");
 
-            var userId = contactAggregate.Contact?.SecurityAccounts?.FirstOrDefault()?.Id;
+            var (userId, knownMembership) = await _organizationMembershipSearchService.ResolveMembershipForOrganizationAsync(
+                contactAggregate.Contact, request.OrganizationId);
+
             if (string.IsNullOrEmpty(userId))
             {
                 return contactAggregate;
             }
 
             var membership = await OrganizationInviteHelper.GetPendingInviteAsync(
-                _organizationMembershipSearchService, userId, request.OrganizationId);
+                _organizationMembershipSearchService, userId, request.OrganizationId, knownMembership);
 
             await _inviteCustomerService.RevokeInviteAsync(membership.Id, cancellationToken);
 

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/RevokeOrganizationInviteCommandHandler.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/RevokeOrganizationInviteCommandHandler.cs
@@ -46,6 +46,10 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
 
             await _inviteCustomerService.RevokeInviteAsync(membership.Id, cancellationToken);
 
+            contactAggregate.Contact.Organizations?.Remove(request.OrganizationId);
+
+            await _contactAggregateRepository.SaveAsync(contactAggregate);
+
             return await _contactAggregateRepository.GetMemberAggregateRootByIdAsync<ContactAggregate>(request.MemberId);
         }
     }

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/RevokeOrganizationInviteCommandHandler.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/RevokeOrganizationInviteCommandHandler.cs
@@ -46,11 +46,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
 
             await _inviteCustomerService.RevokeInviteAsync(membership.Id, cancellationToken);
 
-            contactAggregate.Contact.Organizations?.Remove(request.OrganizationId);
-
-            await _contactAggregateRepository.SaveAsync(contactAggregate);
-
-            return await _contactAggregateRepository.GetMemberAggregateRootByIdAsync<ContactAggregate>(request.MemberId);
+            return contactAggregate;
         }
     }
 }

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/UnlockOrganizationContactCommandHandler.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/UnlockOrganizationContactCommandHandler.cs
@@ -3,7 +3,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using MediatR;
-using VirtoCommerce.CustomerModule.Core.Model;
+using VirtoCommerce.CustomerModule.Core.Extensions;
 using VirtoCommerce.CustomerModule.Core.Services;
 using VirtoCommerce.ProfileExperienceApiModule.Data.Aggregates.Contact;
 
@@ -41,15 +41,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
                 return contactAggregate;
             }
 
-            var searchResult = await _organizationMembershipSearchService.SearchAsync(
-                new OrganizationMembershipSearchCriteria
-                {
-                    UserId = userId,
-                    OrganizationId = request.OrganizationId,
-                    Take = 1
-                });
-
-            var membership = searchResult.Results.FirstOrDefault()
+            var membership = await _organizationMembershipSearchService.GetMembershipAsync(userId, request.OrganizationId)
                 ?? throw new InvalidOperationException($"Contact '{request.MemberId}' has no membership in organization '{request.OrganizationId}'.");
 
             await _organizationMembershipService.UnlockAsync(membership.Id);

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/UnlockOrganizationContactCommandHandler.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/UnlockOrganizationContactCommandHandler.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using MediatR;
@@ -37,7 +36,9 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
             var contactAggregate = await _contactAggregateRepository.GetMemberAggregateRootByIdAsync<ContactAggregate>(request.MemberId)
                 ?? throw new InvalidOperationException($"Contact '{request.MemberId}' not found.");
 
-            var userId = contactAggregate.Contact?.SecurityAccounts?.FirstOrDefault()?.Id;
+            var (userId, _) = await _organizationMembershipSearchService.ResolveMembershipForOrganizationAsync(
+                contactAggregate.Contact, request.OrganizationId);
+
             if (string.IsNullOrEmpty(userId))
             {
                 return contactAggregate;

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Schemas/ContactType.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Schemas/ContactType.cs
@@ -57,6 +57,10 @@ public class ContactType : MemberBaseType<ContactAggregate>
             .Resolve(context => ResolveRolesInOrganization(
                 context, organizationMembershipSearchService, dataLoader, roleManagerFactory, userManagerFactory));
 
+        Field<StringGraphType>("statusInOrganization")
+            .Description("Effective status for the current organization: the organization-specific override if set, otherwise the contact's global status.")
+            .Resolve(context => ResolveStatusInOrganization(context, organizationMembershipSearchService, dataLoader));
+
         Field(x => x.Contact.FirstName);
         Field(x => x.Contact.LastName);
         Field(x => x.Contact.MiddleName, true);
@@ -105,19 +109,28 @@ public class ContactType : MemberBaseType<ContactAggregate>
             .CreateConnection<OrganizationType, ContactAggregate>("organizations")
             .Argument<StringGraphType>("searchPhrase", "Free text search")
             .Argument<StringGraphType>("sort", "Sort expression")
+            .Argument<ListGraphType<StringGraphType>>("statuses", "Filter by the current user's effective status/lock state in each organization (e.g. Invited, Approved, Locked)")
             .PageSize(20);
 
         organizationsConnectionBuilder.ResolveAsync(async context =>
         {
             var response = AbstractTypeFactory<MemberSearchResult>.TryCreateInstance();
             var query = context.GetSearchMembersQuery<SearchOrganizationsQuery>();
+            var organizationIds = context.Source.Contact.Organizations;
+
+            var statuses = context.GetArgument<IList<string>>("statuses");
+            if (statuses is { Count: > 0 } && !organizationIds.IsNullOrEmpty())
+            {
+                organizationIds = (await ResolveMyOrganizationIdsByStatusAsync(
+                    context, organizationMembershipSearchService, organizationIds, statuses)).ToList();
+            }
 
             // If user have no organizations, member search service would return all organizations
             // it means we don't need the search request when user's organization list is empty
-            if (!context.Source.Contact.Organizations.IsNullOrEmpty())
+            if (!organizationIds.IsNullOrEmpty())
             {
                 query.DeepSearch = true;
-                query.ObjectIds = context.Source.Contact.Organizations;
+                query.ObjectIds = organizationIds;
                 response = await mediator.Send(query);
             }
 
@@ -168,6 +181,113 @@ public class ContactType : MemberBaseType<ContactAggregate>
             });
 
         return loader.LoadAsync(userIds).Then(lockedFlags => lockedFlags.Any(locked => locked));
+    }
+
+    private static IDataLoaderResult<string> ResolveStatusInOrganization(
+        IResolveFieldContext<ContactAggregate> context,
+        IOrganizationMembershipSearchService organizationMembershipSearchService,
+        IDataLoaderContextAccessor dataLoader)
+    {
+        var organizationId = context.GetCurrentOrganizationId();
+        var globalStatus = context.Source.Contact.Status;
+
+        if (string.IsNullOrEmpty(organizationId))
+        {
+            return new DataLoaderResult<string>(globalStatus);
+        }
+
+        var userIds = GetSecurityAccountIds(context);
+        if (userIds.Count == 0)
+        {
+            return new DataLoaderResult<string>(globalStatus);
+        }
+
+        var loader = dataLoader.Context.GetOrAddBatchLoader<string, string>(
+            $"contact_statusInOrg_{organizationId}",
+            async ids =>
+            {
+                var idsList = ids.ToList();
+                var memberships = await organizationMembershipSearchService.SearchAllNoCloneAsync(
+                    new OrganizationMembershipSearchCriteria
+                    {
+                        OrganizationId = organizationId,
+                        UserIds = idsList,
+                        Take = idsList.Count,
+                    });
+
+                return (IDictionary<string, string>)memberships
+                    .Where(m => !string.IsNullOrEmpty(m.Status))
+                    .GroupBy(m => m.UserId)
+                    .ToDictionary(g => g.Key, g => g.First().Status);
+            });
+
+        return loader.LoadAsync(userIds).Then(statuses =>
+        {
+            var overrideStatus = statuses.FirstOrDefault(status => !string.IsNullOrEmpty(status));
+            return OrganizationMembership.ResolveEffectiveStatus(overrideStatus, globalStatus);
+        });
+    }
+
+    private const string LockedFilterValue = "Locked";
+
+    private static async Task<IReadOnlyCollection<string>> ResolveMyOrganizationIdsByStatusAsync(
+        IResolveFieldContext<ContactAggregate> context,
+        IOrganizationMembershipSearchService organizationMembershipSearchService,
+        IList<string> organizationIds,
+        IList<string> statuses)
+    {
+        var userId = context.GetCurrentUserId();
+        var globalStatus = context.Source.Contact.Status;
+
+        if (string.IsNullOrEmpty(userId))
+        {
+            return [];
+        }
+
+        var wantsLocked = statuses.Contains(LockedFilterValue);
+        var lifecycleStatuses = statuses.Where(s => s != LockedFilterValue).ToHashSet();
+
+        var memberships = await organizationMembershipSearchService.SearchAllNoCloneAsync(
+            new OrganizationMembershipSearchCriteria
+            {
+                UserId = userId,
+                OrganizationIds = organizationIds,
+            });
+
+        var membershipByOrgId = memberships
+            .Where(m => m.OrganizationId != null)
+            .GroupBy(m => m.OrganizationId)
+            .ToDictionary(g => g.Key, g => g.First());
+
+        var qualifyingOrgIds = new HashSet<string>();
+
+        foreach (var orgId in organizationIds)
+        {
+            membershipByOrgId.TryGetValue(orgId, out var membership);
+
+            if (membership?.IsCurrentlyLocked == true)
+            {
+                if (wantsLocked)
+                {
+                    qualifyingOrgIds.Add(orgId);
+                }
+
+                continue;
+            }
+
+            if (lifecycleStatuses.Count == 0)
+            {
+                continue;
+            }
+
+            var effectiveStatus = OrganizationMembership.ResolveEffectiveStatus(membership?.Status, globalStatus);
+            if (!string.IsNullOrEmpty(effectiveStatus) && lifecycleStatuses.Contains(effectiveStatus))
+            {
+                qualifyingOrgIds.Add(orgId);
+            }
+        }
+
+        return qualifyingOrgIds;
     }
 
     private static IDataLoaderResult<List<Role>> ResolveRolesInOrganization(

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Schemas/ContactType.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Schemas/ContactType.cs
@@ -109,7 +109,7 @@ public class ContactType : MemberBaseType<ContactAggregate>
             .CreateConnection<OrganizationType, ContactAggregate>("organizations")
             .Argument<StringGraphType>("searchPhrase", "Free text search")
             .Argument<StringGraphType>("sort", "Sort expression")
-            .Argument<ListGraphType<StringGraphType>>("statuses", "Filter by the current user's effective status/lock state in each organization (e.g. Invited, Approved, Locked)")
+            .Argument<ListGraphType<StringGraphType>>("statuses", "Filter by this contact's effective status/lock state in each organization (e.g. Invited, Approved, Locked)")
             .PageSize(20);
 
         organizationsConnectionBuilder.ResolveAsync(async context =>
@@ -236,10 +236,10 @@ public class ContactType : MemberBaseType<ContactAggregate>
         IList<string> organizationIds,
         IList<string> statuses)
     {
-        var userId = context.GetCurrentUserId();
+        var userIds = GetSecurityAccountIds(context);
         var globalStatus = context.Source.Contact.Status;
 
-        if (string.IsNullOrEmpty(userId))
+        if (userIds.Count == 0)
         {
             return [];
         }
@@ -250,22 +250,22 @@ public class ContactType : MemberBaseType<ContactAggregate>
         var memberships = await organizationMembershipSearchService.SearchAllNoCloneAsync(
             new OrganizationMembershipSearchCriteria
             {
-                UserId = userId,
+                UserIds = userIds,
                 OrganizationIds = organizationIds,
             });
 
-        var membershipByOrgId = memberships
+        var membershipsByOrgId = memberships
             .Where(m => m.OrganizationId != null)
             .GroupBy(m => m.OrganizationId)
-            .ToDictionary(g => g.Key, g => g.First());
+            .ToDictionary(g => g.Key, g => g.ToList());
 
         var qualifyingOrgIds = new HashSet<string>();
 
         foreach (var orgId in organizationIds)
         {
-            membershipByOrgId.TryGetValue(orgId, out var membership);
+            membershipsByOrgId.TryGetValue(orgId, out var orgMemberships);
 
-            if (membership?.IsCurrentlyLocked == true)
+            if (orgMemberships?.Any(m => m.IsCurrentlyLocked) == true)
             {
                 if (wantsLocked)
                 {
@@ -280,7 +280,8 @@ public class ContactType : MemberBaseType<ContactAggregate>
                 continue;
             }
 
-            var effectiveStatus = OrganizationMembership.ResolveEffectiveStatus(membership?.Status, globalStatus);
+            var overrideStatus = orgMemberships?.Select(m => m.Status).FirstOrDefault(s => !string.IsNullOrEmpty(s));
+            var effectiveStatus = OrganizationMembership.ResolveEffectiveStatus(overrideStatus, globalStatus);
             if (!string.IsNullOrEmpty(effectiveStatus) && lifecycleStatuses.Contains(effectiveStatus))
             {
                 qualifyingOrgIds.Add(orgId);

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Schemas/ContactType.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Schemas/ContactType.cs
@@ -26,6 +26,7 @@ using VirtoCommerce.Xapi.Core.Extensions;
 using VirtoCommerce.Xapi.Core.Helpers;
 using VirtoCommerce.Xapi.Core.Infrastructure;
 using VirtoCommerce.Xapi.Core.Services;
+using CustomerModuleConstants = VirtoCommerce.CustomerModule.Core.ModuleConstants;
 
 namespace VirtoCommerce.ProfileExperienceApiModule.Data.Schemas;
 
@@ -102,13 +103,24 @@ public class ContactType : MemberBaseType<ContactAggregate>
 
         #region Organizations
 
-        Field("organizationsIds", x => x.Contact.Organizations);
+        Field<ListGraphType<StringGraphType>>("organizationsIds")
+            .ResolveAsync(async context =>
+            {
+                var organizationIds = context.Source.Contact.Organizations;
+                if (organizationIds.IsNullOrEmpty())
+                {
+                    return organizationIds;
+                }
+
+                return await ResolveMyOrganizationIdsByStatusAsync(
+                    context, organizationMembershipSearchService, organizationIds, statuses: null);
+            });
 
         var organizationsConnectionBuilder = GraphTypeExtensionHelper
             .CreateConnection<OrganizationType, ContactAggregate>("organizations")
             .Argument<StringGraphType>("searchPhrase", "Free text search")
             .Argument<StringGraphType>("sort", "Sort expression")
-            .Argument<ListGraphType<StringGraphType>>("statuses", "Filter by this contact's effective status/lock state in each organization (e.g. Invited, Approved, Locked)")
+            .Argument<ListGraphType<StringGraphType>>("statuses", "Filter by this contact's effective status/lock state in each organization (e.g. Invited, Approved, Locked). When omitted, organizations the contact is blocked from (Invited/Rejected/Deleted) are hidden by default.")
             .PageSize(20);
 
         organizationsConnectionBuilder.ResolveAsync(async context =>
@@ -117,9 +129,9 @@ public class ContactType : MemberBaseType<ContactAggregate>
             var query = context.GetSearchMembersQuery<SearchOrganizationsQuery>();
             var organizationIds = context.Source.Contact.Organizations;
 
-            var statuses = context.GetArgument<IList<string>>("statuses");
-            if (statuses is { Count: > 0 } && !organizationIds.IsNullOrEmpty())
+            if (!organizationIds.IsNullOrEmpty())
             {
+                var statuses = context.GetArgument<IList<string>>("statuses");
                 organizationIds = (await ResolveMyOrganizationIdsByStatusAsync(
                     context, organizationMembershipSearchService, organizationIds, statuses)).ToList();
             }
@@ -259,8 +271,9 @@ public class ContactType : MemberBaseType<ContactAggregate>
             return [];
         }
 
-        var wantsLocked = statuses.Contains(LockedFilterValue);
-        var lifecycleStatuses = statuses.Where(s => s != LockedFilterValue).ToHashSet();
+        var hasExplicitFilter = statuses is { Count: > 0 };
+        var wantsLocked = hasExplicitFilter && statuses.Contains(LockedFilterValue);
+        var lifecycleStatuses = hasExplicitFilter ? statuses.Where(s => s != LockedFilterValue).ToHashSet() : null;
 
         var memberships = await organizationMembershipSearchService.SearchAllNoCloneAsync(
             new OrganizationMembershipSearchCriteria
@@ -290,13 +303,24 @@ public class ContactType : MemberBaseType<ContactAggregate>
                 continue;
             }
 
+            var overrideStatus = orgMemberships?.Select(m => m.Status).FirstOrDefault(s => !string.IsNullOrEmpty(s));
+            var effectiveStatus = OrganizationMembership.ResolveEffectiveStatus(overrideStatus, globalStatus);
+
+            if (!hasExplicitFilter)
+            {
+                if (!CustomerModuleConstants.MembershipStatuses.IsBlocking(effectiveStatus))
+                {
+                    qualifyingOrgIds.Add(orgId);
+                }
+
+                continue;
+            }
+
             if (lifecycleStatuses.Count == 0)
             {
                 continue;
             }
 
-            var overrideStatus = orgMemberships?.Select(m => m.Status).FirstOrDefault(s => !string.IsNullOrEmpty(s));
-            var effectiveStatus = OrganizationMembership.ResolveEffectiveStatus(overrideStatus, globalStatus);
             if (!string.IsNullOrEmpty(effectiveStatus) && lifecycleStatuses.Contains(effectiveStatus))
             {
                 qualifyingOrgIds.Add(orgId);

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Schemas/InputAcceptRejectOrganizationInviteType.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Schemas/InputAcceptRejectOrganizationInviteType.cs
@@ -1,0 +1,13 @@
+using GraphQL.Types;
+using VirtoCommerce.Xapi.Core.Schemas;
+
+namespace VirtoCommerce.ProfileExperienceApiModule.Data.Schemas
+{
+    public class InputAcceptRejectOrganizationInviteType : ExtendableInputObjectGraphType
+    {
+        public InputAcceptRejectOrganizationInviteType()
+        {
+            Field<NonNullGraphType<StringGraphType>>("OrganizationId").Description("ID of the organization the current user was invited to");
+        }
+    }
+}

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Schemas/InputRegisterByInvitationType.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Schemas/InputRegisterByInvitationType.cs
@@ -16,6 +16,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Schemas
             Field<NonNullGraphType<StringGraphType>>(nameof(RegisterByInvitationCommand.Username)).Description("Username");
             Field<NonNullGraphType<StringGraphType>>(nameof(RegisterByInvitationCommand.Password)).Description("Password");
             Field<StringGraphType>(nameof(RegisterByInvitationCommand.CustomerOrderId)).Description("Customer order Id to be associated with this user.");
+            Field<StringGraphType>(nameof(RegisterByInvitationCommand.OrganizationId)).Description("ID of the organization this invite was for. Only this organization's pending invite is approved on registration.");
         }
     }
 }

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Schemas/InputResendOrganizationInviteType.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Schemas/InputResendOrganizationInviteType.cs
@@ -1,0 +1,16 @@
+using GraphQL.Types;
+using VirtoCommerce.ProfileExperienceApiModule.Data.Commands;
+using VirtoCommerce.Xapi.Core.Schemas;
+
+namespace VirtoCommerce.ProfileExperienceApiModule.Data.Schemas
+{
+    public class InputResendOrganizationInviteType : ExtendableInputObjectGraphType
+    {
+        public InputResendOrganizationInviteType()
+        {
+            Field<NonNullGraphType<StringGraphType>>("MemberId").Description("Contact member ID");
+            Field<NonNullGraphType<StringGraphType>>(nameof(ResendOrganizationInviteCommand.UrlSuffix)).Description("Optional URL suffix: relative URL to the page which handles registration by invite");
+            Field<StringGraphType>(nameof(ResendOrganizationInviteCommand.Message)).Description("Optional message to include into the invitation email");
+        }
+    }
+}

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Schemas/InputResendOrganizationInviteType.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Schemas/InputResendOrganizationInviteType.cs
@@ -9,7 +9,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Schemas
         public InputResendOrganizationInviteType()
         {
             Field<NonNullGraphType<StringGraphType>>("MemberId").Description("Contact member ID");
-            Field<NonNullGraphType<StringGraphType>>(nameof(ResendOrganizationInviteCommand.UrlSuffix)).Description("Optional URL suffix: relative URL to the page which handles registration by invite");
+            Field<StringGraphType>(nameof(ResendOrganizationInviteCommand.UrlSuffix)).Description("Optional URL suffix: relative URL to the page which handles registration by invite");
             Field<StringGraphType>(nameof(ResendOrganizationInviteCommand.Message)).Description("Optional message to include into the invitation email");
         }
     }

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Schemas/InputRevokeOrganizationInviteType.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Schemas/InputRevokeOrganizationInviteType.cs
@@ -1,0 +1,13 @@
+using GraphQL.Types;
+using VirtoCommerce.Xapi.Core.Schemas;
+
+namespace VirtoCommerce.ProfileExperienceApiModule.Data.Schemas
+{
+    public class InputRevokeOrganizationInviteType : ExtendableInputObjectGraphType
+    {
+        public InputRevokeOrganizationInviteType()
+        {
+            Field<NonNullGraphType<StringGraphType>>("MemberId").Description("Contact member ID");
+        }
+    }
+}

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Schemas/OrganizationType.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Schemas/OrganizationType.cs
@@ -7,6 +7,7 @@ using GraphQL.Types;
 using MediatR;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
+using VirtoCommerce.CustomerModule.Core.Extensions;
 using VirtoCommerce.CustomerModule.Core.Model;
 using VirtoCommerce.CustomerModule.Core.Model.Search;
 using VirtoCommerce.CustomerModule.Core.Services;
@@ -19,6 +20,7 @@ using VirtoCommerce.ProfileExperienceApiModule.Data.Commands;
 using VirtoCommerce.ProfileExperienceApiModule.Data.Extensions;
 using VirtoCommerce.ProfileExperienceApiModule.Data.Services;
 using VirtoCommerce.StoreModule.Core.Services;
+using VirtoCommerce.Xapi.Core.Extensions;
 using VirtoCommerce.Xapi.Core.Helpers;
 using VirtoCommerce.Xapi.Core.Infrastructure;
 using VirtoCommerce.Xapi.Core.Services;
@@ -48,12 +50,17 @@ public class OrganizationType : MemberBaseType<OrganizationAggregate>
         Field(x => x.Organization.OwnerId, true).Description("Owner id");
         Field(x => x.Organization.ParentId, true).Description("Parent id");
 
+        Field<StringGraphType>("myStatusInOrganization")
+            .Description("Current user's effective status in this organization: the organization-specific override if set, otherwise the contact's global status.")
+            .ResolveAsync(async context => await ResolveMyStatusInOrganizationAsync(context, organizationMembershipService, memberService, userManagerFactory));
+
         #region Contacts
 
         var connectionBuilder = GraphTypeExtensionHelper.CreateConnection<ContactType, OrganizationAggregate>("contacts")
             .Argument<StringGraphType>("searchPhrase", "Free text search")
             .Argument<StringGraphType>("sort", "Sort expression")
             .Argument<ListGraphType<StringGraphType>>("roleIds", "Filter contacts by role IDs (org-level, membership, or global)")
+            .Argument<ListGraphType<StringGraphType>>("statuses", "Filter contacts by effective status/lock state for this organization (e.g. Approved, Invited, Locked)")
             .PageSize(20);
 
         connectionBuilder.ResolveAsync(async context =>
@@ -82,7 +89,27 @@ public class OrganizationType : MemberBaseType<OrganizationAggregate>
                         return new PagedConnection<ContactAggregate>([], query.Skip, query.Take, 0);
                     }
 
-                    query.ObjectIds = filterIds.ToList();
+                    query.ObjectIds = IntersectObjectIds(query.ObjectIds, filterIds);
+                }
+            }
+
+            var statuses = context.GetArgument<IList<string>>("statuses");
+            if (statuses is { Count: > 0 })
+            {
+                var (filterRequired, filterIds) = await ResolveStatusFilterAsync(
+                    orgId,
+                    statuses,
+                    memberSearchService,
+                    organizationMembershipService);
+
+                if (filterRequired)
+                {
+                    if (filterIds.Count == 0)
+                    {
+                        return new PagedConnection<ContactAggregate>([], query.Skip, query.Take, 0);
+                    }
+
+                    query.ObjectIds = IntersectObjectIds(query.ObjectIds, filterIds);
                 }
             }
 
@@ -95,6 +122,33 @@ public class OrganizationType : MemberBaseType<OrganizationAggregate>
         AddField(connectionBuilder.FieldType);
 
         #endregion
+    }
+
+    private static async Task<string> ResolveMyStatusInOrganizationAsync(
+        IResolveFieldContext<OrganizationAggregate> context,
+        IOrganizationMembershipSearchService organizationMembershipSearchService,
+        IMemberService memberService,
+        Func<UserManager<ApplicationUser>> userManagerFactory)
+    {
+        var userId = context.GetCurrentUserId();
+        if (string.IsNullOrEmpty(userId))
+        {
+            return null;
+        }
+
+        using var userManager = userManagerFactory();
+        var user = await userManager.FindByIdAsync(userId);
+        if (string.IsNullOrEmpty(user?.MemberId))
+        {
+            return null;
+        }
+
+        var memberTask = memberService.GetByIdAsync(user.MemberId);
+        var membershipTask = organizationMembershipSearchService.GetMembershipAsync(userId, context.Source.Organization.Id);
+
+        await Task.WhenAll(memberTask, membershipTask);
+
+        return OrganizationMembership.ResolveEffectiveStatus(membershipTask.Result?.Status, memberTask.Result?.Status);
     }
 
     private static async Task<IReadOnlyCollection<string>> GetContactIdsByGlobalRolesAsync(
@@ -191,5 +245,78 @@ public class OrganizationType : MemberBaseType<OrganizationAggregate>
                 .Where(id => !string.IsNullOrEmpty(id)));
 
         return (filterRequired: true, ids: qualifyingContactIds);
+    }
+
+    private const string LockedFilterValue = "Locked";
+
+    private static async Task<(bool filterRequired, IReadOnlyCollection<string> ids)> ResolveStatusFilterAsync(
+        string orgId,
+        IList<string> statuses,
+        IMemberSearchService memberSearchService,
+        IOrganizationMembershipSearchService organizationMembershipService)
+    {
+        var membershipsTask = organizationMembershipService.SearchAllNoCloneAsync(
+            new OrganizationMembershipSearchCriteria { OrganizationId = orgId });
+        var contactsTask = memberSearchService.SearchAllAsync(
+            new MembersSearchCriteria { MemberId = orgId });
+
+        await Task.WhenAll(membershipsTask, contactsTask);
+
+        var allOrgMemberships = membershipsTask.Result;
+        var orgContacts = contactsTask.Result;
+
+        var membershipByUserId = allOrgMemberships
+            .GroupBy(m => m.UserId)
+            .ToDictionary(g => g.Key, g => g.First());
+
+        var wantsLocked = statuses.Contains(LockedFilterValue);
+        var lifecycleStatuses = statuses.Where(s => s != LockedFilterValue).ToHashSet();
+
+        var qualifyingContactIds = new HashSet<string>();
+
+        foreach (var contact in orgContacts)
+        {
+            var securityAccountIds = (contact as IHasSecurityAccounts)?.SecurityAccounts?
+                .Select(sa => sa.Id)
+                .Where(id => !string.IsNullOrEmpty(id)) ?? [];
+
+            OrganizationMembership membership = null;
+            foreach (var securityAccountId in securityAccountIds)
+            {
+                if (membershipByUserId.TryGetValue(securityAccountId, out membership))
+                {
+                    break;
+                }
+            }
+
+            if (membership?.IsCurrentlyLocked == true)
+            {
+                if (wantsLocked)
+                {
+                    qualifyingContactIds.Add(contact.Id);
+                }
+
+                continue;
+            }
+
+            if (lifecycleStatuses.Count == 0)
+            {
+                continue;
+            }
+
+            var effectiveStatus = OrganizationMembership.ResolveEffectiveStatus(membership?.Status, contact.Status);
+
+            if (!string.IsNullOrEmpty(effectiveStatus) && lifecycleStatuses.Contains(effectiveStatus))
+            {
+                qualifyingContactIds.Add(contact.Id);
+            }
+        }
+
+        return (filterRequired: true, ids: qualifyingContactIds);
+    }
+
+    private static IList<string> IntersectObjectIds(IList<string> existing, IReadOnlyCollection<string> additional)
+    {
+        return existing == null ? additional.ToList() : existing.Intersect(additional).ToList();
     }
 }

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Schemas/OrganizationType.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Schemas/OrganizationType.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using GraphQL;
+using GraphQL.Builders;
 using GraphQL.Types;
 using MediatR;
 using Microsoft.AspNetCore.Identity;
@@ -54,8 +55,6 @@ public class OrganizationType : MemberBaseType<OrganizationAggregate>
             .Description("Current user's effective status in this organization: the organization-specific override if set, otherwise the contact's global status.")
             .ResolveAsync(async context => await ResolveMyStatusInOrganizationAsync(context, organizationMembershipService, memberService, userManagerFactory));
 
-        #region Contacts
-
         var connectionBuilder = GraphTypeExtensionHelper.CreateConnection<ContactType, OrganizationAggregate>("contacts")
             .Argument<StringGraphType>("searchPhrase", "Free text search")
             .Argument<StringGraphType>("sort", "Sort expression")
@@ -63,65 +62,74 @@ public class OrganizationType : MemberBaseType<OrganizationAggregate>
             .Argument<ListGraphType<StringGraphType>>("statuses", "Filter contacts by effective status/lock state for this organization (e.g. Approved, Invited, Locked)")
             .PageSize(20);
 
-        connectionBuilder.ResolveAsync(async context =>
-        {
-            var query = context.GetSearchMembersQuery<SearchContactsQuery>();
-            var orgId = context.Source.Organization.Id;
-            query.MemberId = orgId;
-            query.DeepSearch = false;
-
-            var roleIds = context.GetArgument<IList<string>>("roleIds");
-            if (roleIds is { Count: > 0 })
-            {
-                var (filterRequired, filterIds) = await ResolveRoleFilterAsync(
-                    orgId,
-                    roleIds,
-                    memberService,
-                    memberSearchService,
-                    organizationMembershipService,
-                    roleManagerFactory,
-                    userManagerFactory);
-
-                if (filterRequired)
-                {
-                    if (filterIds.Count == 0)
-                    {
-                        return new PagedConnection<ContactAggregate>([], query.Skip, query.Take, 0);
-                    }
-
-                    query.ObjectIds = IntersectObjectIds(query.ObjectIds, filterIds);
-                }
-            }
-
-            var statuses = context.GetArgument<IList<string>>("statuses");
-            if (statuses is { Count: > 0 })
-            {
-                var (filterRequired, filterIds) = await ResolveStatusFilterAsync(
-                    orgId,
-                    statuses,
-                    memberSearchService,
-                    organizationMembershipService);
-
-                if (filterRequired)
-                {
-                    if (filterIds.Count == 0)
-                    {
-                        return new PagedConnection<ContactAggregate>([], query.Skip, query.Take, 0);
-                    }
-
-                    query.ObjectIds = IntersectObjectIds(query.ObjectIds, filterIds);
-                }
-            }
-
-            var response = await mediator.Send(query);
-
-            return new PagedConnection<ContactAggregate>(
-                response.Results.Select(x => factory.Create<ContactAggregate>(x)), query.Skip, query.Take,
-                response.TotalCount);
-        });
+        connectionBuilder.ResolveAsync(context => ResolveContactsConnectionAsync(
+            context, mediator, factory, memberService, memberSearchService, organizationMembershipService, roleManagerFactory, userManagerFactory));
         AddField(connectionBuilder.FieldType);
+    }
 
-        #endregion
+    private static async Task<object> ResolveContactsConnectionAsync(
+        IResolveConnectionContext<OrganizationAggregate> context,
+        IMediator mediator,
+        IMemberAggregateFactory factory,
+        IMemberService memberService,
+        IMemberSearchService memberSearchService,
+        IOrganizationMembershipSearchService organizationMembershipService,
+        Func<RoleManager<Role>> roleManagerFactory,
+        Func<UserManager<ApplicationUser>> userManagerFactory)
+    {
+        var query = context.GetSearchMembersQuery<SearchContactsQuery>();
+        var orgId = context.Source.Organization.Id;
+        query.MemberId = orgId;
+        query.DeepSearch = false;
+
+        var roleIds = context.GetArgument<IList<string>>("roleIds");
+        if (roleIds is { Count: > 0 })
+        {
+            var (filterRequired, filterIds) = await ResolveRoleFilterAsync(
+                orgId,
+                roleIds,
+                memberService,
+                memberSearchService,
+                organizationMembershipService,
+                roleManagerFactory,
+                userManagerFactory);
+
+            if (filterRequired)
+            {
+                if (filterIds.Count == 0)
+                {
+                    return new PagedConnection<ContactAggregate>([], query.Skip, query.Take, 0);
+                }
+
+                query.ObjectIds = IntersectObjectIds(query.ObjectIds, filterIds);
+            }
+        }
+
+        var statuses = context.GetArgument<IList<string>>("statuses");
+        if (statuses is { Count: > 0 })
+        {
+            var (filterRequired, filterIds) = await ResolveStatusFilterAsync(
+                orgId,
+                statuses,
+                memberSearchService,
+                organizationMembershipService);
+
+            if (filterRequired)
+            {
+                if (filterIds.Count == 0)
+                {
+                    return new PagedConnection<ContactAggregate>([], query.Skip, query.Take, 0);
+                }
+
+                query.ObjectIds = IntersectObjectIds(query.ObjectIds, filterIds);
+            }
+        }
+
+        var response = await mediator.Send(query);
+
+        return new PagedConnection<ContactAggregate>(
+            response.Results.Select(x => factory.Create<ContactAggregate>(x)), query.Skip, query.Take,
+            response.TotalCount);
     }
 
     private static async Task<string> ResolveMyStatusInOrganizationAsync(
@@ -262,57 +270,56 @@ public class OrganizationType : MemberBaseType<OrganizationAggregate>
 
         await Task.WhenAll(membershipsTask, contactsTask);
 
-        var allOrgMemberships = membershipsTask.Result;
-        var orgContacts = contactsTask.Result;
-
-        var membershipByUserId = allOrgMemberships
+        var membershipByUserId = membershipsTask.Result
             .GroupBy(m => m.UserId)
             .ToDictionary(g => g.Key, g => g.First());
 
         var wantsLocked = statuses.Contains(LockedFilterValue);
         var lifecycleStatuses = statuses.Where(s => s != LockedFilterValue).ToHashSet();
 
-        var qualifyingContactIds = new HashSet<string>();
+        var qualifyingContactIds = contactsTask.Result
+            .Where(contact => ContactMatchesStatusFilter(contact, membershipByUserId, wantsLocked, lifecycleStatuses))
+            .Select(contact => contact.Id)
+            .ToHashSet();
 
-        foreach (var contact in orgContacts)
+        return (filterRequired: true, ids: qualifyingContactIds);
+    }
+
+    private static bool ContactMatchesStatusFilter(
+        Member contact, IDictionary<string, OrganizationMembership> membershipByUserId, bool wantsLocked, ISet<string> lifecycleStatuses)
+    {
+        var membership = FindMembership(contact, membershipByUserId);
+
+        if (membership?.IsCurrentlyLocked == true)
         {
-            var securityAccountIds = (contact as IHasSecurityAccounts)?.SecurityAccounts?
-                .Select(sa => sa.Id)
-                .Where(id => !string.IsNullOrEmpty(id)) ?? [];
+            return wantsLocked;
+        }
 
-            OrganizationMembership membership = null;
-            foreach (var securityAccountId in securityAccountIds)
+        if (lifecycleStatuses.Count == 0)
+        {
+            return false;
+        }
+
+        var effectiveStatus = OrganizationMembership.ResolveEffectiveStatus(membership?.Status, contact.Status);
+
+        return !string.IsNullOrEmpty(effectiveStatus) && lifecycleStatuses.Contains(effectiveStatus);
+    }
+
+    private static OrganizationMembership FindMembership(Member contact, IDictionary<string, OrganizationMembership> membershipByUserId)
+    {
+        var securityAccountIds = (contact as IHasSecurityAccounts)?.SecurityAccounts?
+            .Select(sa => sa.Id)
+            .Where(id => !string.IsNullOrEmpty(id)) ?? [];
+
+        foreach (var securityAccountId in securityAccountIds)
+        {
+            if (membershipByUserId.TryGetValue(securityAccountId, out var membership))
             {
-                if (membershipByUserId.TryGetValue(securityAccountId, out membership))
-                {
-                    break;
-                }
-            }
-
-            if (membership?.IsCurrentlyLocked == true)
-            {
-                if (wantsLocked)
-                {
-                    qualifyingContactIds.Add(contact.Id);
-                }
-
-                continue;
-            }
-
-            if (lifecycleStatuses.Count == 0)
-            {
-                continue;
-            }
-
-            var effectiveStatus = OrganizationMembership.ResolveEffectiveStatus(membership?.Status, contact.Status);
-
-            if (!string.IsNullOrEmpty(effectiveStatus) && lifecycleStatuses.Contains(effectiveStatus))
-            {
-                qualifyingContactIds.Add(contact.Id);
+                return membership;
             }
         }
 
-        return (filterRequired: true, ids: qualifyingContactIds);
+        return null;
     }
 
     private static IList<string> IntersectObjectIds(IList<string> existing, IReadOnlyCollection<string> additional)

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Schemas/OrganizationType.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Schemas/OrganizationType.cs
@@ -4,11 +4,11 @@ using System.Linq;
 using System.Threading.Tasks;
 using GraphQL;
 using GraphQL.Builders;
+using GraphQL.DataLoader;
 using GraphQL.Types;
 using MediatR;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
-using VirtoCommerce.CustomerModule.Core.Extensions;
 using VirtoCommerce.CustomerModule.Core.Model;
 using VirtoCommerce.CustomerModule.Core.Model.Search;
 using VirtoCommerce.CustomerModule.Core.Services;
@@ -40,7 +40,8 @@ public class OrganizationType : MemberBaseType<OrganizationAggregate>
         IMemberSearchService memberSearchService,
         IOrganizationMembershipSearchService organizationMembershipService,
         Func<RoleManager<Role>> roleManagerFactory,
-        Func<UserManager<ApplicationUser>> userManagerFactory)
+        Func<UserManager<ApplicationUser>> userManagerFactory,
+        IDataLoaderContextAccessor dataLoader)
         : base(storeService, dynamicPropertyResolverService, memberAddressService)
     {
         Name = "Organization";
@@ -53,7 +54,7 @@ public class OrganizationType : MemberBaseType<OrganizationAggregate>
 
         Field<StringGraphType>("myStatusInOrganization")
             .Description("Current user's effective status in this organization: the organization-specific override if set, otherwise the contact's global status.")
-            .ResolveAsync(async context => await ResolveMyStatusInOrganizationAsync(context, organizationMembershipService, memberService, userManagerFactory));
+            .Resolve(context => ResolveMyStatusInOrganization(context, organizationMembershipService, memberService, userManagerFactory, dataLoader));
 
         var connectionBuilder = GraphTypeExtensionHelper.CreateConnection<ContactType, OrganizationAggregate>("contacts")
             .Argument<StringGraphType>("searchPhrase", "Free text search")
@@ -132,31 +133,63 @@ public class OrganizationType : MemberBaseType<OrganizationAggregate>
             response.TotalCount);
     }
 
-    private static async Task<string> ResolveMyStatusInOrganizationAsync(
+    private static IDataLoaderResult<string> ResolveMyStatusInOrganization(
         IResolveFieldContext<OrganizationAggregate> context,
         IOrganizationMembershipSearchService organizationMembershipSearchService,
         IMemberService memberService,
-        Func<UserManager<ApplicationUser>> userManagerFactory)
+        Func<UserManager<ApplicationUser>> userManagerFactory,
+        IDataLoaderContextAccessor dataLoader)
+    {
+        var loader = dataLoader.Context.GetOrAddBatchLoader<string, string>(
+            "organization_myStatusInOrg",
+            async organizationIds => await ResolveMyStatusesByOrganizationAsync(
+                context, organizationMembershipSearchService, memberService, userManagerFactory, organizationIds));
+
+        return loader.LoadAsync(context.Source.Organization.Id);
+    }
+
+    private static async Task<IDictionary<string, string>> ResolveMyStatusesByOrganizationAsync(
+        IResolveFieldContext<OrganizationAggregate> context,
+        IOrganizationMembershipSearchService organizationMembershipSearchService,
+        IMemberService memberService,
+        Func<UserManager<ApplicationUser>> userManagerFactory,
+        IEnumerable<string> organizationIds)
     {
         var userId = context.GetCurrentUserId();
         if (string.IsNullOrEmpty(userId))
         {
-            return null;
+            return new Dictionary<string, string>();
         }
 
         using var userManager = userManagerFactory();
         var user = await userManager.FindByIdAsync(userId);
         if (string.IsNullOrEmpty(user?.MemberId))
         {
-            return null;
+            return new Dictionary<string, string>();
         }
 
-        var memberTask = memberService.GetByIdAsync(user.MemberId);
-        var membershipTask = organizationMembershipSearchService.GetMembershipAsync(userId, context.Source.Organization.Id);
+        var member = await memberService.GetByIdAsync(user.MemberId);
+        var globalStatus = member?.Status;
 
-        await Task.WhenAll(memberTask, membershipTask);
+        var idsList = organizationIds.ToList();
+        var memberships = await organizationMembershipSearchService.SearchAllNoCloneAsync(new OrganizationMembershipSearchCriteria
+        {
+            UserId = userId,
+            OrganizationIds = idsList,
+        });
 
-        return OrganizationMembership.ResolveEffectiveStatus(membershipTask.Result?.Status, memberTask.Result?.Status);
+        var membershipByOrgId = memberships
+            .Where(m => m.OrganizationId != null)
+            .GroupBy(m => m.OrganizationId)
+            .ToDictionary(g => g.Key, g => g.First());
+
+        return idsList.ToDictionary(
+            orgId => orgId,
+            orgId =>
+            {
+                membershipByOrgId.TryGetValue(orgId, out var membership);
+                return OrganizationMembership.ResolveEffectiveStatus(membership?.Status, globalStatus);
+            });
     }
 
     private static async Task<IReadOnlyCollection<string>> GetContactIdsByGlobalRolesAsync(

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Schemas/OrganizationType.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Schemas/OrganizationType.cs
@@ -67,6 +67,23 @@ public class OrganizationType : MemberBaseType<OrganizationAggregate>
         AddField(connectionBuilder.FieldType);
     }
 
+    [Obsolete("Use the constructor without IMediator. The mediator is resolved from context.RequestServices per request.", DiagnosticId = "VC0015", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
+    public OrganizationType(
+        IStoreService storeService,
+        IDynamicPropertyResolverService dynamicPropertyResolverService,
+        IMemberAddressService memberAddressService,
+        IMediator mediator,
+        IMemberAggregateFactory factory,
+        IMemberService memberService,
+        IMemberSearchService memberSearchService,
+        IOrganizationMembershipSearchService organizationMembershipService,
+        Func<RoleManager<Role>> roleManagerFactory,
+        Func<UserManager<ApplicationUser>> userManagerFactory,
+        IDataLoaderContextAccessor dataLoader)
+        : this(storeService, dynamicPropertyResolverService, memberAddressService, factory, memberService, memberSearchService, organizationMembershipService, roleManagerFactory, userManagerFactory, dataLoader)
+    {
+    }
+
     private static async Task<object> ResolveContactsConnectionAsync(
         IResolveConnectionContext<OrganizationAggregate> context,
         IMemberAggregateFactory factory,
@@ -188,23 +205,6 @@ public class OrganizationType : MemberBaseType<OrganizationAggregate>
                 membershipByOrgId.TryGetValue(orgId, out var membership);
                 return OrganizationMembership.ResolveEffectiveStatus(membership?.Status, globalStatus);
             });
-    }
-
-    [Obsolete("Use the constructor without IMediator. The mediator is resolved from context.RequestServices per request.", DiagnosticId = "VC0015", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
-    public OrganizationType(
-        IStoreService storeService,
-        IDynamicPropertyResolverService dynamicPropertyResolverService,
-        IMemberAddressService memberAddressService,
-        IMediator mediator,
-        IMemberAggregateFactory factory,
-        IMemberService memberService,
-        IMemberSearchService memberSearchService,
-        IOrganizationMembershipSearchService organizationMembershipService,
-        Func<RoleManager<Role>> roleManagerFactory,
-        Func<UserManager<ApplicationUser>> userManagerFactory,
-        IDataLoaderContextAccessor dataLoader)
-        : this(storeService, dynamicPropertyResolverService, memberAddressService, factory, memberService, memberSearchService, organizationMembershipService, roleManagerFactory, userManagerFactory, dataLoader)
-    {
     }
 
     private static async Task<IReadOnlyCollection<string>> GetContactIdsByGlobalRolesAsync(

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Schemas/ProfileSchema.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Schemas/ProfileSchema.cs
@@ -632,6 +632,58 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Schemas
                         })
                         .FieldType);
 
+            _ = schema.Mutation.AddField(FieldBuilder<ContactAggregate, ContactAggregate>
+                        .Create("acceptOrganizationInvite", GraphTypeExtensionHelper.GetActualType<ContactType>())
+                        .Argument(GraphTypeExtensionHelper.GetActualComplexType<NonNullGraphType<InputAcceptRejectOrganizationInviteType>>(), _commandName)
+                        .ResolveAsync(async context =>
+                        {
+                            var type = GenericTypeHelper.GetActualType<AcceptOrganizationInviteCommand>();
+                            var command = (AcceptOrganizationInviteCommand)context.GetArgument(type, _commandName);
+                            command.UserId = context.GetCurrentUserId();
+                            await CheckAuthAsync(context, command);
+                            return await _mediator.Send(command);
+                        })
+                        .FieldType);
+
+            _ = schema.Mutation.AddField(FieldBuilder<ContactAggregate, ContactAggregate>
+                        .Create("rejectOrganizationInvite", GraphTypeExtensionHelper.GetActualType<ContactType>())
+                        .Argument(GraphTypeExtensionHelper.GetActualComplexType<NonNullGraphType<InputAcceptRejectOrganizationInviteType>>(), _commandName)
+                        .ResolveAsync(async context =>
+                        {
+                            var type = GenericTypeHelper.GetActualType<RejectOrganizationInviteCommand>();
+                            var command = (RejectOrganizationInviteCommand)context.GetArgument(type, _commandName);
+                            command.UserId = context.GetCurrentUserId();
+                            await CheckAuthAsync(context, command);
+                            return await _mediator.Send(command);
+                        })
+                        .FieldType);
+
+            _ = schema.Mutation.AddField(FieldBuilder<ContactAggregate, ContactAggregate>
+                        .Create("revokeOrganizationInvite", GraphTypeExtensionHelper.GetActualType<ContactType>())
+                        .Argument(GraphTypeExtensionHelper.GetActualComplexType<NonNullGraphType<InputLockUnlockOrganizationContactType>>(), _commandName)
+                        .ResolveAsync(async context =>
+                        {
+                            var type = GenericTypeHelper.GetActualType<RevokeOrganizationInviteCommand>();
+                            var command = (RevokeOrganizationInviteCommand)context.GetArgument(type, _commandName);
+                            command.OrganizationId = context.GetCurrentOrganizationId();
+                            await CheckAuthAsync(context, command, ProfilePermissions.MyOrganizationEdit);
+                            return await _mediator.Send(command);
+                        })
+                        .FieldType);
+
+            _ = schema.Mutation.AddField(FieldBuilder<object, IdentityResultResponse>
+                        .Create("resendOrganizationInvite", GraphTypeExtensionHelper.GetActualType<CustomIdentityResultType>())
+                        .Argument(GraphTypeExtensionHelper.GetActualComplexType<NonNullGraphType<InputResendOrganizationInviteType>>(), _commandName)
+                        .ResolveAsync(async context =>
+                        {
+                            var type = GenericTypeHelper.GetActualType<ResendOrganizationInviteCommand>();
+                            var command = (ResendOrganizationInviteCommand)context.GetArgument(type, _commandName);
+                            command.OrganizationId = context.GetCurrentOrganizationId();
+                            await CheckAuthAsync(context, command, ProfilePermissions.MyOrganizationEdit);
+                            return await _mediator.Send(command);
+                        })
+                        .FieldType);
+
             #region register by invitation
 
 #pragma warning disable S125 // Sections of code should not be commented out

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Schemas/ProfileSchema.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Schemas/ProfileSchema.cs
@@ -660,7 +660,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Schemas
 
             _ = schema.Mutation.AddField(FieldBuilder<ContactAggregate, ContactAggregate>
                         .Create("revokeOrganizationInvite", GraphTypeExtensionHelper.GetActualType<ContactType>())
-                        .Argument(GraphTypeExtensionHelper.GetActualComplexType<NonNullGraphType<InputLockUnlockOrganizationContactType>>(), _commandName)
+                        .Argument(GraphTypeExtensionHelper.GetActualComplexType<NonNullGraphType<InputRevokeOrganizationInviteType>>(), _commandName)
                         .ResolveAsync(async context =>
                         {
                             var type = GenericTypeHelper.GetActualType<RevokeOrganizationInviteCommand>();

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/VirtoCommerce.ProfileExperienceApiModule.Data.csproj
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/VirtoCommerce.ProfileExperienceApiModule.Data.csproj
@@ -7,7 +7,7 @@
     <SonarQubeTestProject>false</SonarQubeTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="VirtoCommerce.CustomerModule.Core" Version="3.1014.0" />
+    <PackageReference Include="VirtoCommerce.CustomerModule.Core" Version="3.1021.0-alpha.1002-vcst-5281" />
     <PackageReference Include="VirtoCommerce.MarketingModule.Core" Version="3.1005.0" />
     <PackageReference Include="VirtoCommerce.NotificationsModule.Core" Version="3.1009.0" />
     <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.1039.0" />

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/VirtoCommerce.ProfileExperienceApiModule.Data.csproj
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/VirtoCommerce.ProfileExperienceApiModule.Data.csproj
@@ -7,7 +7,7 @@
     <SonarQubeTestProject>false</SonarQubeTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="VirtoCommerce.CustomerModule.Core" Version="3.1021.0-alpha.1004-vcst-5281" />
+    <PackageReference Include="VirtoCommerce.CustomerModule.Core" Version="3.1021.0" />
     <PackageReference Include="VirtoCommerce.MarketingModule.Core" Version="3.1005.0" />
     <PackageReference Include="VirtoCommerce.NotificationsModule.Core" Version="3.1009.0" />
     <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.1039.0" />

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/VirtoCommerce.ProfileExperienceApiModule.Data.csproj
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/VirtoCommerce.ProfileExperienceApiModule.Data.csproj
@@ -7,7 +7,7 @@
     <SonarQubeTestProject>false</SonarQubeTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="VirtoCommerce.CustomerModule.Core" Version="3.1021.0-alpha.1002-vcst-5281" />
+    <PackageReference Include="VirtoCommerce.CustomerModule.Core" Version="3.1021.0-alpha.1004-vcst-5281" />
     <PackageReference Include="VirtoCommerce.MarketingModule.Core" Version="3.1005.0" />
     <PackageReference Include="VirtoCommerce.NotificationsModule.Core" Version="3.1009.0" />
     <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.1039.0" />

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Web/module.manifest
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Web/module.manifest
@@ -6,7 +6,7 @@
 
   <platformVersion>3.1039.0</platformVersion>
   <dependencies>
-    <dependency id="VirtoCommerce.Customer" version="3.1014.0" />
+    <dependency id="VirtoCommerce.Customer" version="3.1021.0-alpha.1002-vcst-5281" />
     <dependency id="VirtoCommerce.Marketing" version="3.1005.0" optional="true" />
     <dependency id="VirtoCommerce.Notifications" version="3.1009.0" />
     <dependency id="VirtoCommerce.Pricing" version="3.1003.0" optional="true" />

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Web/module.manifest
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Web/module.manifest
@@ -6,7 +6,7 @@
 
   <platformVersion>3.1039.0</platformVersion>
   <dependencies>
-    <dependency id="VirtoCommerce.Customer" version="3.1021.0-alpha.1004-vcst-5281" />
+    <dependency id="VirtoCommerce.Customer" version="3.1021.0" />
     <dependency id="VirtoCommerce.Marketing" version="3.1005.0" optional="true" />
     <dependency id="VirtoCommerce.Notifications" version="3.1009.0" />
     <dependency id="VirtoCommerce.Pricing" version="3.1003.0" optional="true" />

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Web/module.manifest
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Web/module.manifest
@@ -6,7 +6,7 @@
 
   <platformVersion>3.1039.0</platformVersion>
   <dependencies>
-    <dependency id="VirtoCommerce.Customer" version="3.1021.0-alpha.1002-vcst-5281" />
+    <dependency id="VirtoCommerce.Customer" version="3.1021.0-alpha.1004-vcst-5281" />
     <dependency id="VirtoCommerce.Marketing" version="3.1005.0" optional="true" />
     <dependency id="VirtoCommerce.Notifications" version="3.1009.0" />
     <dependency id="VirtoCommerce.Pricing" version="3.1003.0" optional="true" />

--- a/tests/VirtoCommerce.ProfileExperienceApiModule.Tests/Authorization/ProfileAuthorizationHandlerTests.cs
+++ b/tests/VirtoCommerce.ProfileExperienceApiModule.Tests/Authorization/ProfileAuthorizationHandlerTests.cs
@@ -1,0 +1,152 @@
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Moq;
+using VirtoCommerce.CustomerModule.Core;
+using VirtoCommerce.CustomerModule.Core.Model;
+using VirtoCommerce.CustomerModule.Core.Services;
+using VirtoCommerce.Platform.Core.Security;
+using VirtoCommerce.ProfileExperienceApiModule.Data.Aggregates.Organization;
+using VirtoCommerce.ProfileExperienceApiModule.Data.Authorization;
+using Xunit;
+
+namespace VirtoCommerce.ProfileExperienceApiModule.Tests.Authorization
+{
+    public class ProfileAuthorizationHandlerTests
+    {
+        private const string UserId = "user-1";
+        private const string ContactId = "contact-1";
+        private const string OrgId = "org-1";
+
+        private readonly Mock<IMemberService> _memberServiceMock = new();
+        private readonly Mock<IOrganizationMembershipSearchService> _membershipSearchServiceMock = new();
+        private readonly Mock<UserManager<ApplicationUser>> _userManagerMock;
+
+        public ProfileAuthorizationHandlerTests()
+        {
+            ClaimsPrincipalExtensions.UserIdClaimTypes = [ClaimTypes.NameIdentifier];
+
+            _userManagerMock = new Mock<UserManager<ApplicationUser>>(
+                new Mock<IUserStore<ApplicationUser>>().Object, null, null, null, null, null, null, null, null);
+
+            _memberServiceMock
+                .Setup(x => x.GetByIdAsync(UserId, MemberResponseGroup.Default.ToString()))
+                .ReturnsAsync((Member)null);
+
+            _userManagerMock
+                .Setup(x => x.FindByIdAsync(UserId))
+                .ReturnsAsync(new ApplicationUser { Id = UserId, MemberId = ContactId });
+        }
+
+        [Fact]
+        public async Task OrganizationAggregate_ApprovedNoOverride_Succeeds()
+        {
+            // Arrange
+            SetupCurrentContact(new Contact { Id = ContactId, Organizations = [OrgId], Status = ModuleConstants.MembershipStatuses.Approved });
+            SetupMembership(null);
+
+            // Act
+            var authContext = await HandleAsync(BuildOrganizationResource());
+
+            // Assert
+            Assert.True(authContext.HasSucceeded);
+        }
+
+        [Fact]
+        public async Task OrganizationAggregate_GloballyRejected_NoMembershipOverride_Fails()
+        {
+            // Arrange — the contact was invited/added to the org but rejected/removed globally; no per-org
+            // override exists, so the global Rejected status must block access to the org's data.
+            SetupCurrentContact(new Contact { Id = ContactId, Organizations = [OrgId], Status = ModuleConstants.MembershipStatuses.Rejected });
+            SetupMembership(null);
+
+            // Act
+            var authContext = await HandleAsync(BuildOrganizationResource());
+
+            // Assert
+            Assert.False(authContext.HasSucceeded);
+        }
+
+        [Fact]
+        public async Task OrganizationAggregate_MembershipOverrideApproved_SucceedsDespiteGlobalRejected()
+        {
+            // Arrange — a per-org Approved override wins over the globally Rejected contact status.
+            SetupCurrentContact(new Contact { Id = ContactId, Organizations = [OrgId], Status = ModuleConstants.MembershipStatuses.Rejected });
+            SetupMembership(new OrganizationMembership { OrganizationId = OrgId, Status = ModuleConstants.MembershipStatuses.Approved });
+
+            // Act
+            var authContext = await HandleAsync(BuildOrganizationResource());
+
+            // Assert
+            Assert.True(authContext.HasSucceeded);
+        }
+
+        [Fact]
+        public async Task OrganizationAggregate_LockedMembership_Fails()
+        {
+            // Arrange — locked membership blocks access regardless of the (otherwise fine) effective status.
+            SetupCurrentContact(new Contact { Id = ContactId, Organizations = [OrgId], Status = ModuleConstants.MembershipStatuses.Approved });
+            SetupMembership(new OrganizationMembership { OrganizationId = OrgId, Status = ModuleConstants.MembershipStatuses.Approved, IsLocked = true });
+
+            // Act
+            var authContext = await HandleAsync(BuildOrganizationResource());
+
+            // Assert
+            Assert.False(authContext.HasSucceeded);
+        }
+
+        [Fact]
+        public async Task OrganizationAggregate_NotMemberOfOrganization_Fails_WithoutQueryingMemberships()
+        {
+            // Arrange — the contact was never added to this org's Organizations list at all.
+            SetupCurrentContact(new Contact { Id = ContactId, Organizations = [], Status = ModuleConstants.MembershipStatuses.Approved });
+
+            // Act
+            var authContext = await HandleAsync(BuildOrganizationResource());
+
+            // Assert
+            Assert.False(authContext.HasSucceeded);
+            _membershipSearchServiceMock.Verify(
+                x => x.SearchAsync(It.IsAny<OrganizationMembershipSearchCriteria>(), It.IsAny<bool>()),
+                Times.Never);
+        }
+
+        private void SetupCurrentContact(Contact contact)
+        {
+            _memberServiceMock
+                .Setup(x => x.GetByIdAsync(ContactId, MemberResponseGroup.Default.ToString()))
+                .ReturnsAsync(contact);
+        }
+
+        private void SetupMembership(OrganizationMembership membership)
+        {
+            _membershipSearchServiceMock
+                .Setup(x => x.SearchAsync(
+                    It.Is<OrganizationMembershipSearchCriteria>(c => c.UserId == UserId && c.OrganizationId == OrgId),
+                    It.IsAny<bool>()))
+                .ReturnsAsync(new OrganizationMembershipSearchResult
+                {
+                    Results = membership == null ? [] : [membership],
+                });
+        }
+
+        private static OrganizationAggregate BuildOrganizationResource() =>
+            new() { Member = new Organization { Id = OrgId } };
+
+        private async Task<AuthorizationHandlerContext> HandleAsync(object resource)
+        {
+            var handler = new ProfileAuthorizationHandler(
+                _memberServiceMock.Object,
+                _membershipSearchServiceMock.Object,
+                () => _userManagerMock.Object);
+
+            var principal = new ClaimsPrincipal(new ClaimsIdentity([new Claim(ClaimTypes.NameIdentifier, UserId)]));
+            var authContext = new AuthorizationHandlerContext([new ProfileAuthorizationRequirement()], principal, resource);
+
+            await handler.HandleAsync(authContext);
+
+            return authContext;
+        }
+    }
+}

--- a/tests/VirtoCommerce.ProfileExperienceApiModule.Tests/Handlers/ConfirmEmailCommandHandlerTests.cs
+++ b/tests/VirtoCommerce.ProfileExperienceApiModule.Tests/Handlers/ConfirmEmailCommandHandlerTests.cs
@@ -1,0 +1,96 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Options;
+using Moq;
+using VirtoCommerce.CustomerModule.Core.Model;
+using VirtoCommerce.CustomerModule.Core.Services;
+using VirtoCommerce.Platform.Core.Security;
+using VirtoCommerce.ProfileExperienceApiModule.Data;
+using VirtoCommerce.ProfileExperienceApiModule.Data.Commands;
+using VirtoCommerce.StoreModule.Core.Services;
+using VirtoCommerce.Xapi.Tests.Helpers;
+using Xunit;
+
+namespace VirtoCommerce.ProfileExperienceApiModule.Tests.Handlers
+{
+    public class ConfirmEmailCommandHandlerTests : MoqHelper
+    {
+        private readonly Mock<IStoreService> _storeServiceMock = new();
+        private readonly Mock<IMemberService> _memberServiceMock = new();
+        private readonly Mock<UserManager<ApplicationUser>> _userManagerMock;
+
+        public ConfirmEmailCommandHandlerTests()
+        {
+            _userManagerMock = new Mock<UserManager<ApplicationUser>>(
+                new Mock<IUserStore<ApplicationUser>>().Object, null, null, null, null, null, null, null, null);
+        }
+
+        [Fact]
+        public async Task Handle_LockedContact_ApprovesContactAfterConfirmation()
+        {
+            // Arrange
+            var user = new ApplicationUser { Id = "user-1", UserName = "test@test.com", MemberId = "contact-1", StoreId = "store-1" };
+            var contact = new Contact { Id = "contact-1", Status = ModuleConstants.ContactStatuses.Locked };
+
+            _userManagerMock.Setup(x => x.FindByIdAsync("user-1")).ReturnsAsync(user);
+            _userManagerMock.Setup(x => x.ConfirmEmailAsync(user, It.IsAny<string>())).ReturnsAsync(IdentityResult.Success);
+            _userManagerMock.Setup(x => x.SetLockoutEndDateAsync(user, null)).ReturnsAsync(IdentityResult.Success);
+
+            _memberServiceMock.Setup(x => x.GetByIdAsync("contact-1", It.IsAny<string>())).ReturnsAsync(contact);
+            _memberServiceMock.Setup(x => x.SaveChangesAsync(It.IsAny<Member[]>())).Returns(Task.CompletedTask);
+
+            var handler = BuildHandler();
+            var command = new ConfirmEmailCommand { UserId = "user-1", Token = "token" };
+
+            // Act
+            var result = await handler.Handle(command, CancellationToken.None);
+
+            // Assert
+            Assert.True(result.Succeeded);
+            _memberServiceMock.Verify(
+                x => x.SaveChangesAsync(It.Is<Member[]>(members =>
+                    members.Length == 1 && ((Contact)members[0]).Status == ModuleConstants.ContactStatuses.Approved)),
+                Times.Once);
+
+            // The same contact is reused for both the status update and the registration notification lookup
+            _memberServiceMock.Verify(x => x.GetByIdAsync("contact-1", It.IsAny<string>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task Handle_AlreadyApprovedContact_DoesNotSaveContact()
+        {
+            // Arrange
+            var user = new ApplicationUser { Id = "user-1", UserName = "test@test.com", MemberId = "contact-1", StoreId = "store-1" };
+            var contact = new Contact { Id = "contact-1", Status = ModuleConstants.ContactStatuses.Approved };
+
+            _userManagerMock.Setup(x => x.FindByIdAsync("user-1")).ReturnsAsync(user);
+            _userManagerMock.Setup(x => x.ConfirmEmailAsync(user, It.IsAny<string>())).ReturnsAsync(IdentityResult.Success);
+            _userManagerMock.Setup(x => x.SetLockoutEndDateAsync(user, null)).ReturnsAsync(IdentityResult.Success);
+
+            _memberServiceMock.Setup(x => x.GetByIdAsync("contact-1", It.IsAny<string>())).ReturnsAsync(contact);
+
+            var handler = BuildHandler();
+            var command = new ConfirmEmailCommand { UserId = "user-1", Token = "token" };
+
+            // Act
+            var result = await handler.Handle(command, CancellationToken.None);
+
+            // Assert
+            Assert.True(result.Succeeded);
+            _memberServiceMock.Verify(x => x.SaveChangesAsync(It.IsAny<Member[]>()), Times.Never);
+        }
+
+        private ConfirmEmailCommandHandler BuildHandler()
+        {
+            var userManager = _userManagerMock.Object;
+
+            return new ConfirmEmailCommandHandler(
+                _storeServiceMock.Object,
+                _memberServiceMock.Object,
+                _mediatorMock.Object,
+                () => userManager,
+                Options.Create(new AuthorizationOptions()));
+        }
+    }
+}

--- a/tests/VirtoCommerce.ProfileExperienceApiModule.Tests/Handlers/InviteUserCommandHandlerTests.cs
+++ b/tests/VirtoCommerce.ProfileExperienceApiModule.Tests/Handlers/InviteUserCommandHandlerTests.cs
@@ -1,0 +1,97 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using VirtoCommerce.CustomerModule.Core.Model;
+using VirtoCommerce.CustomerModule.Core.Services;
+using VirtoCommerce.ProfileExperienceApiModule.Data.Commands;
+using Xunit;
+
+namespace VirtoCommerce.ProfileExperienceApiModule.Tests.Handlers
+{
+    public class InviteUserCommandHandlerTests
+    {
+        [Fact]
+        public async Task Handle_MapsCommandToInviteCustomerRequest_AndDelegatesToSharedService()
+        {
+            // Arrange
+            InviteCustomerRequest capturedRequest = null;
+
+            var inviteCustomerServiceMock = new Mock<IInviteCustomerService>();
+            inviteCustomerServiceMock
+                .Setup(s => s.InviteCustomerAsyc(It.IsAny<InviteCustomerRequest>(), It.IsAny<CancellationToken>()))
+                .Callback<InviteCustomerRequest, CancellationToken>((request, _) => capturedRequest = request)
+                .ReturnsAsync(new InviteCustomerResult { Succeeded = true, Errors = [] });
+
+            var handler = new InviteUserCommandHandler(inviteCustomerServiceMock.Object);
+
+            var command = new InviteUserCommand
+            {
+                StoreId = "store1",
+                OrganizationId = "org1",
+                UrlSuffix = "/confirm-invitation",
+                Emails = ["existing@test.com"],
+                Message = "Welcome!",
+                RoleIds = ["org-employee"],
+                CustomerOrderId = "order1",
+            };
+
+            // Act
+            var result = await handler.Handle(command, CancellationToken.None);
+
+            // Assert
+            Assert.True(result.Succeeded);
+            Assert.Empty(result.Errors);
+
+            Assert.NotNull(capturedRequest);
+            Assert.Equal(command.StoreId, capturedRequest.StoreId);
+            Assert.Equal(command.OrganizationId, capturedRequest.OrganizationId);
+            Assert.Equal(command.UrlSuffix, capturedRequest.UrlSuffix);
+            Assert.Equal(command.Emails, capturedRequest.Emails);
+            Assert.Equal(command.Message, capturedRequest.Message);
+            Assert.Equal(command.RoleIds, capturedRequest.RoleIds);
+            Assert.Equal(command.CustomerOrderId, capturedRequest.AdditionalParameters["customerOrderId"]);
+        }
+
+        [Fact]
+        public async Task Handle_MapsInviteCustomerErrors_ToIdentityErrorInfo()
+        {
+            // Arrange
+            var inviteCustomerServiceMock = new Mock<IInviteCustomerService>();
+            inviteCustomerServiceMock
+                .Setup(s => s.InviteCustomerAsyc(It.IsAny<InviteCustomerRequest>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new InviteCustomerResult
+                {
+                    Succeeded = false,
+                    Errors =
+                    [
+                        new()
+                        {
+                            Code = "AlreadyMemberOfOrganization",
+                            Description = "User with email 'existing@test.com' is already a member of organization 'org1'",
+                            Parameter = "org1",
+                            Email = "existing@test.com",
+                        },
+                    ],
+                });
+
+            var handler = new InviteUserCommandHandler(inviteCustomerServiceMock.Object);
+
+            var command = new InviteUserCommand
+            {
+                StoreId = "store1",
+                OrganizationId = "org1",
+                Emails = ["existing@test.com"],
+                RoleIds = ["org-employee"],
+            };
+
+            // Act
+            var result = await handler.Handle(command, CancellationToken.None);
+
+            // Assert
+            Assert.False(result.Succeeded);
+            var error = Assert.Single(result.Errors);
+            Assert.Equal("AlreadyMemberOfOrganization", error.Code);
+            Assert.Equal("org1", error.Parameter);
+        }
+    }
+}

--- a/tests/VirtoCommerce.ProfileExperienceApiModule.Tests/Handlers/LockOrganizationContactCommandHandlerTests.cs
+++ b/tests/VirtoCommerce.ProfileExperienceApiModule.Tests/Handlers/LockOrganizationContactCommandHandlerTests.cs
@@ -113,6 +113,60 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Tests.Handlers
         }
 
         [Fact]
+        public async Task Handle_MultipleSecurityAccounts_FindsMembershipOnNonFirstAccount()
+        {
+            // Arrange — the contact has two security accounts (e.g. after linking an SSO login); the
+            // membership belongs to the second one, not FirstOrDefault(). Must still be locked correctly.
+            const string firstUserId = "user-1";
+            const string secondUserId = "user-2";
+            const string membershipId = "membership-2";
+
+            var contact = new Contact
+            {
+                SecurityAccounts =
+                [
+                    new ApplicationUser { Id = firstUserId },
+                    new ApplicationUser { Id = secondUserId },
+                ],
+            };
+            var aggregate = new ContactAggregate { Member = contact };
+
+            _contactRepoMock
+                .Setup(x => x.GetMemberAggregateRootByIdAsync<ContactAggregate>(It.IsAny<string>()))
+                .ReturnsAsync(aggregate);
+
+            _membershipSearchServiceMock
+                .Setup(x => x.SearchAsync(
+                    It.Is<OrganizationMembershipSearchCriteria>(c =>
+                        c.UserIds != null && c.UserIds.Contains(firstUserId) && c.UserIds.Contains(secondUserId) && c.OrganizationId == "org-1"),
+                    It.IsAny<bool>()))
+                .ReturnsAsync(new OrganizationMembershipSearchResult
+                {
+                    Results = [new OrganizationMembership { Id = membershipId, UserId = secondUserId }],
+                    TotalCount = 1,
+                });
+
+            _membershipSearchServiceMock
+                .Setup(x => x.SearchAsync(
+                    It.Is<OrganizationMembershipSearchCriteria>(c => c.UserId == secondUserId && c.OrganizationId == "org-1"),
+                    It.IsAny<bool>()))
+                .ReturnsAsync(new OrganizationMembershipSearchResult
+                {
+                    Results = [new OrganizationMembership { Id = membershipId, UserId = secondUserId }],
+                    TotalCount = 1,
+                });
+
+            var handler = BuildHandler();
+            var command = new LockOrganizationContactCommand { MemberId = "contact-1", OrganizationId = "org-1" };
+
+            // Act
+            await handler.Handle(command, CancellationToken.None);
+
+            // Assert
+            _membershipServiceMock.Verify(x => x.LockAsync(membershipId, It.IsAny<DateTime?>()), Times.Once);
+        }
+
+        [Fact]
         public async Task Handle_MembershipNotFound_ThrowsInvalidOperationException()
         {
             // Arrange

--- a/tests/VirtoCommerce.ProfileExperienceApiModule.Tests/Handlers/RegisterByInvitationCommandHandlerTests.cs
+++ b/tests/VirtoCommerce.ProfileExperienceApiModule.Tests/Handlers/RegisterByInvitationCommandHandlerTests.cs
@@ -1,0 +1,105 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using MediatR;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Options;
+using Moq;
+using VirtoCommerce.CustomerModule.Core;
+using VirtoCommerce.CustomerModule.Core.Model;
+using VirtoCommerce.CustomerModule.Core.Services;
+using VirtoCommerce.Platform.Core.Security;
+using VirtoCommerce.ProfileExperienceApiModule.Data.Commands;
+using VirtoCommerce.ProfileExperienceApiModule.Data.Configuration;
+using VirtoCommerce.ProfileExperienceApiModule.Data.Validators;
+using VirtoCommerce.StoreModule.Core.Services;
+using Xunit;
+
+namespace VirtoCommerce.ProfileExperienceApiModule.Tests.Handlers
+{
+    public class RegisterByInvitationCommandHandlerTests
+    {
+        private const string UserId = "user-1";
+        private const string OrgId1 = "org-1";
+        private const string OrgId2 = "org-2";
+
+        private readonly Mock<IOrganizationMembershipSearchService> _membershipSearchServiceMock = new();
+        private readonly Mock<IOrganizationMembershipService> _membershipServiceMock = new();
+        private readonly TestableHandler _handler;
+
+        public RegisterByInvitationCommandHandlerTests()
+        {
+            _handler = new TestableHandler(
+                new Mock<IWebHostEnvironment>().Object,
+                () => new Mock<UserManager<ApplicationUser>>(
+                    new Mock<IUserStore<ApplicationUser>>().Object, null, null, null, null, null, null, null, null).Object,
+                new Mock<IMemberService>().Object,
+                new Mock<IStoreService>().Object,
+                new Mock<IMediator>().Object,
+                new RegisterByInvitationCommandValidator(Options.Create(new InputValidationOptions())),
+                _membershipServiceMock.Object,
+                _membershipSearchServiceMock.Object);
+        }
+
+        [Fact]
+        public async Task ApproveInvitedMemberships_MultipleOrganizations_SavesInSingleBatch()
+        {
+            // Arrange — the user was invited to two organizations; approving on registration must not
+            // read-then-write each membership row individually.
+            var membership1 = new OrganizationMembership { Id = "m1", UserId = UserId, OrganizationId = OrgId1, Status = ModuleConstants.MembershipStatuses.Invited };
+            var membership2 = new OrganizationMembership { Id = "m2", UserId = UserId, OrganizationId = OrgId2, Status = ModuleConstants.MembershipStatuses.Invited };
+
+            _membershipSearchServiceMock
+                .Setup(x => x.SearchAsync(
+                    It.Is<OrganizationMembershipSearchCriteria>(c => c.UserId == UserId && c.OrganizationIds.Count == 2),
+                    It.IsAny<bool>()))
+                .ReturnsAsync(new OrganizationMembershipSearchResult { Results = [membership1, membership2], TotalCount = 2 });
+
+            // Act
+            await _handler.ApproveInvitedMembershipsPublicAsync(UserId, null, [OrgId1, OrgId2]);
+
+            // Assert — one SaveChangesAsync call carrying both updated memberships, not two separate calls
+            Assert.Equal(ModuleConstants.MembershipStatuses.Approved, membership1.Status);
+            Assert.Equal(ModuleConstants.MembershipStatuses.Approved, membership2.Status);
+
+            _membershipServiceMock.Verify(
+                x => x.SaveChangesAsync(It.Is<IList<OrganizationMembership>>(list => list.Count == 2)),
+                Times.Once);
+            _membershipServiceMock.Verify(x => x.SetStatusAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task ApproveInvitedMemberships_NoPendingInvites_DoesNotCallSaveChanges()
+        {
+            // Arrange
+            _membershipSearchServiceMock
+                .Setup(x => x.SearchAsync(It.IsAny<OrganizationMembershipSearchCriteria>(), It.IsAny<bool>()))
+                .ReturnsAsync(new OrganizationMembershipSearchResult { Results = [], TotalCount = 0 });
+
+            // Act
+            await _handler.ApproveInvitedMembershipsPublicAsync(UserId, OrgId1, null);
+
+            // Assert
+            _membershipServiceMock.Verify(x => x.SaveChangesAsync(It.IsAny<IList<OrganizationMembership>>()), Times.Never);
+        }
+
+        private class TestableHandler : RegisterByInvitationCommandHandler
+        {
+            public TestableHandler(
+                IWebHostEnvironment environment,
+                System.Func<UserManager<ApplicationUser>> userManager,
+                IMemberService memberService,
+                IStoreService storeService,
+                IMediator mediator,
+                RegisterByInvitationCommandValidator validator,
+                IOrganizationMembershipService organizationMembershipService,
+                IOrganizationMembershipSearchService organizationMembershipSearchService)
+                : base(environment, userManager, memberService, storeService, mediator, validator, organizationMembershipService, organizationMembershipSearchService)
+            {
+            }
+
+            public Task ApproveInvitedMembershipsPublicAsync(string userId, string organizationId, IList<string> contactOrganizationIds) =>
+                ApproveInvitedMembershipsAsync(userId, organizationId, contactOrganizationIds);
+        }
+    }
+}

--- a/tests/VirtoCommerce.ProfileExperienceApiModule.Tests/Handlers/RegisterRequestCommandHandlerTests.cs
+++ b/tests/VirtoCommerce.ProfileExperienceApiModule.Tests/Handlers/RegisterRequestCommandHandlerTests.cs
@@ -7,6 +7,7 @@ using MediatR;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Options;
 using Moq;
+using VirtoCommerce.CustomerModule.Core;
 using VirtoCommerce.CustomerModule.Core.Model;
 using VirtoCommerce.CustomerModule.Core.Services;
 using VirtoCommerce.NotificationsModule.Core.Services;
@@ -46,12 +47,14 @@ public class RegisterRequestCommandHandlerTests : MoqHelper
         // Act
         await handler.InvokeCreateOrganizationMembershipAsync(account, "org-1", role);
 
-        // Assert
+        // Assert — the user just created and owns this organization, so the membership must be immediately
+        // Approved regardless of Customer.ContactDefaultStatus, not inherited from the (possibly pending) contact.
         _membershipServiceMock.Verify(
             x => x.SaveChangesAsync(It.Is<IList<OrganizationMembership>>(list =>
                 list.Count == 1 &&
                 list[0].UserId == "user-1" &&
                 list[0].OrganizationId == "org-1" &&
+                list[0].Status == ModuleConstants.MembershipStatuses.Approved &&
                 list[0].Roles.Count == 1 &&
                 list[0].Roles[0].RoleId == "role-1" &&
                 list[0].Roles[0].RoleName == "org-maintainer")),

--- a/tests/VirtoCommerce.ProfileExperienceApiModule.Tests/Handlers/RejectOrganizationInviteCommandHandlerTests.cs
+++ b/tests/VirtoCommerce.ProfileExperienceApiModule.Tests/Handlers/RejectOrganizationInviteCommandHandlerTests.cs
@@ -20,7 +20,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Tests.Handlers
         private const string MembershipId = "membership1";
 
         [Fact]
-        public async Task Handle_PendingInvite_SetsRejected_AndRemovesOrgFromContact()
+        public async Task Handle_PendingInvite_SetsRejected_KeepsOrgOnContact()
         {
             // Arrange
             var contact = new Contact
@@ -63,13 +63,14 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Tests.Handlers
             // Act
             var result = await handler.Handle(command, CancellationToken.None);
 
-            // Assert
+            // Assert — the organization stays in Contact.Organizations: the admin members grid is driven by this
+            // relation, so removing it here would hide the (still-auditable) rejected membership from that list.
             Assert.Same(contactAggregate, result);
-            Assert.DoesNotContain(OrgId, contact.Organizations);
+            Assert.Contains(OrgId, contact.Organizations);
             membershipServiceMock.Verify(
                 s => s.SetStatusAsync(MembershipId, ModuleConstants.MembershipStatuses.Rejected),
                 Times.Once);
-            aggregateRepositoryMock.Verify(r => r.SaveAsync(contactAggregate), Times.Once);
+            aggregateRepositoryMock.Verify(r => r.SaveAsync(It.IsAny<ContactAggregate>()), Times.Never);
         }
     }
 }

--- a/tests/VirtoCommerce.ProfileExperienceApiModule.Tests/Handlers/RejectOrganizationInviteCommandHandlerTests.cs
+++ b/tests/VirtoCommerce.ProfileExperienceApiModule.Tests/Handlers/RejectOrganizationInviteCommandHandlerTests.cs
@@ -1,6 +1,6 @@
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Identity;
 using Moq;
 using VirtoCommerce.CustomerModule.Core;
 using VirtoCommerce.CustomerModule.Core.Model;
@@ -12,7 +12,7 @@ using Xunit;
 
 namespace VirtoCommerce.ProfileExperienceApiModule.Tests.Handlers
 {
-    public class RevokeOrganizationInviteCommandHandlerTests
+    public class RejectOrganizationInviteCommandHandlerTests
     {
         private const string MemberId = "member1";
         private const string UserId = "user1";
@@ -20,7 +20,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Tests.Handlers
         private const string MembershipId = "membership1";
 
         [Fact]
-        public async Task Handle_ResolvesMembershipId_AndDelegatesToSharedService()
+        public async Task Handle_PendingInvite_SetsRejected_AndRemovesOrgFromContact()
         {
             // Arrange
             var contact = new Contact
@@ -46,17 +46,19 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Tests.Handlers
                     Results = [new OrganizationMembership { Id = MembershipId, Status = ModuleConstants.MembershipStatuses.Invited }],
                 });
 
-            var inviteCustomerServiceMock = new Mock<IInviteCustomerService>();
-            inviteCustomerServiceMock
-                .Setup(s => s.RevokeInviteAsync(MembershipId, It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new InviteCustomerResult { Succeeded = true, Errors = new List<InviteCustomerError>() });
+            var membershipServiceMock = new Mock<IOrganizationMembershipService>();
 
-            var handler = new RevokeOrganizationInviteCommandHandler(
+            var userManagerMock = new Mock<UserManager<ApplicationUser>>(
+                new Mock<IUserStore<ApplicationUser>>().Object, null, null, null, null, null, null, null, null);
+            userManagerMock.Setup(x => x.FindByIdAsync(UserId)).ReturnsAsync(new ApplicationUser { Id = UserId, MemberId = MemberId });
+
+            var handler = new RejectOrganizationInviteCommandHandler(
                 aggregateRepositoryMock.Object,
+                membershipServiceMock.Object,
                 membershipSearchServiceMock.Object,
-                inviteCustomerServiceMock.Object);
+                () => userManagerMock.Object);
 
-            var command = new RevokeOrganizationInviteCommand { MemberId = MemberId, OrganizationId = OrgId };
+            var command = new RejectOrganizationInviteCommand { UserId = UserId, OrganizationId = OrgId };
 
             // Act
             var result = await handler.Handle(command, CancellationToken.None);
@@ -64,8 +66,9 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Tests.Handlers
             // Assert
             Assert.Same(contactAggregate, result);
             Assert.DoesNotContain(OrgId, contact.Organizations);
-            inviteCustomerServiceMock.Verify(s => s.RevokeInviteAsync(MembershipId, It.IsAny<CancellationToken>()), Times.Once);
-            aggregateRepositoryMock.Verify(r => r.GetMemberAggregateRootByIdAsync<ContactAggregate>(MemberId), Times.Exactly(2));
+            membershipServiceMock.Verify(
+                s => s.SetStatusAsync(MembershipId, ModuleConstants.MembershipStatuses.Rejected),
+                Times.Once);
             aggregateRepositoryMock.Verify(r => r.SaveAsync(contactAggregate), Times.Once);
         }
     }

--- a/tests/VirtoCommerce.ProfileExperienceApiModule.Tests/Handlers/RemoveMemberFromOrganizationCommandHandlerTests.cs
+++ b/tests/VirtoCommerce.ProfileExperienceApiModule.Tests/Handlers/RemoveMemberFromOrganizationCommandHandlerTests.cs
@@ -1,0 +1,130 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using VirtoCommerce.CustomerModule.Core.Model;
+using VirtoCommerce.CustomerModule.Core.Services;
+using VirtoCommerce.Platform.Core.Security;
+using VirtoCommerce.ProfileExperienceApiModule.Data.Aggregates.Contact;
+using VirtoCommerce.ProfileExperienceApiModule.Data.Commands;
+using Xunit;
+
+namespace VirtoCommerce.ProfileExperienceApiModule.Tests.Handlers
+{
+    public class RemoveMemberFromOrganizationCommandHandlerTests
+    {
+        private const string ContactId = "contact1";
+        private const string UserId = "user1";
+        private const string OrgId = "org1";
+        private const string MembershipId = "membership1";
+
+        [Fact]
+        public async Task Handle_MembershipExists_RemovesOrgFromContact_AndDeletesMembership()
+        {
+            // Arrange
+            var contact = new Contact { Id = ContactId, Organizations = [OrgId], SecurityAccounts = [new ApplicationUser { Id = UserId }] };
+            var contactAggregate = new ContactAggregate { Member = contact };
+
+            var aggregateRepositoryMock = new Mock<IContactAggregateRepository>();
+            aggregateRepositoryMock
+                .Setup(r => r.GetMemberAggregateRootByIdAsync<ContactAggregate>(ContactId))
+                .ReturnsAsync(contactAggregate);
+
+            var membershipSearchServiceMock = new Mock<IOrganizationMembershipSearchService>();
+            membershipSearchServiceMock
+                .Setup(s => s.SearchAsync(
+                    It.Is<OrganizationMembershipSearchCriteria>(c => c.UserId == UserId && c.OrganizationId == OrgId),
+                    It.IsAny<bool>()))
+                .ReturnsAsync(new OrganizationMembershipSearchResult
+                {
+                    Results = [new OrganizationMembership { Id = MembershipId }],
+                });
+
+            var membershipServiceMock = new Mock<IOrganizationMembershipService>();
+
+            var handler = new RemoveMemberFromOrganizationCommandHandler(
+                aggregateRepositoryMock.Object,
+                membershipServiceMock.Object,
+                membershipSearchServiceMock.Object);
+
+            var command = new RemoveMemberFromOrganizationCommand { ContactId = ContactId, OrganizationId = OrgId };
+
+            // Act
+            var result = await handler.Handle(command, CancellationToken.None);
+
+            // Assert
+            Assert.Same(contactAggregate, result);
+            Assert.DoesNotContain(OrgId, contact.Organizations);
+            aggregateRepositoryMock.Verify(r => r.SaveAsync(contactAggregate), Times.Once);
+            membershipServiceMock.Verify(
+                s => s.DeleteAsync(It.Is<IList<string>>(ids => ids.Count == 1 && ids[0] == MembershipId), false),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task Handle_NoMembershipFound_DoesNotCallDelete()
+        {
+            // Arrange
+            var contact = new Contact { Id = ContactId, Organizations = [OrgId], SecurityAccounts = [new ApplicationUser { Id = UserId }] };
+            var contactAggregate = new ContactAggregate { Member = contact };
+
+            var aggregateRepositoryMock = new Mock<IContactAggregateRepository>();
+            aggregateRepositoryMock
+                .Setup(r => r.GetMemberAggregateRootByIdAsync<ContactAggregate>(ContactId))
+                .ReturnsAsync(contactAggregate);
+
+            var membershipSearchServiceMock = new Mock<IOrganizationMembershipSearchService>();
+            membershipSearchServiceMock
+                .Setup(s => s.SearchAsync(It.IsAny<OrganizationMembershipSearchCriteria>(), It.IsAny<bool>()))
+                .ReturnsAsync(new OrganizationMembershipSearchResult { Results = [] });
+
+            var membershipServiceMock = new Mock<IOrganizationMembershipService>();
+
+            var handler = new RemoveMemberFromOrganizationCommandHandler(
+                aggregateRepositoryMock.Object,
+                membershipServiceMock.Object,
+                membershipSearchServiceMock.Object);
+
+            var command = new RemoveMemberFromOrganizationCommand { ContactId = ContactId, OrganizationId = OrgId };
+
+            // Act
+            await handler.Handle(command, CancellationToken.None);
+
+            // Assert
+            membershipServiceMock.Verify(s => s.DeleteAsync(It.IsAny<IList<string>>(), It.IsAny<bool>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task Handle_NoSecurityAccount_SkipsMembershipLookup_AndDelete()
+        {
+            // Arrange — a contact without a linked user account (e.g. never registered): nothing to search for.
+            var contact = new Contact { Id = ContactId, Organizations = [OrgId], SecurityAccounts = [] };
+            var contactAggregate = new ContactAggregate { Member = contact };
+
+            var aggregateRepositoryMock = new Mock<IContactAggregateRepository>();
+            aggregateRepositoryMock
+                .Setup(r => r.GetMemberAggregateRootByIdAsync<ContactAggregate>(ContactId))
+                .ReturnsAsync(contactAggregate);
+
+            var membershipSearchServiceMock = new Mock<IOrganizationMembershipSearchService>();
+            var membershipServiceMock = new Mock<IOrganizationMembershipService>();
+
+            var handler = new RemoveMemberFromOrganizationCommandHandler(
+                aggregateRepositoryMock.Object,
+                membershipServiceMock.Object,
+                membershipSearchServiceMock.Object);
+
+            var command = new RemoveMemberFromOrganizationCommand { ContactId = ContactId, OrganizationId = OrgId };
+
+            // Act
+            await handler.Handle(command, CancellationToken.None);
+
+            // Assert
+            Assert.DoesNotContain(OrgId, contact.Organizations);
+            membershipSearchServiceMock.Verify(
+                s => s.SearchAsync(It.IsAny<OrganizationMembershipSearchCriteria>(), It.IsAny<bool>()),
+                Times.Never);
+            membershipServiceMock.Verify(s => s.DeleteAsync(It.IsAny<IList<string>>(), It.IsAny<bool>()), Times.Never);
+        }
+    }
+}

--- a/tests/VirtoCommerce.ProfileExperienceApiModule.Tests/Handlers/RemoveMemberFromOrganizationCommandHandlerTests.cs
+++ b/tests/VirtoCommerce.ProfileExperienceApiModule.Tests/Handlers/RemoveMemberFromOrganizationCommandHandlerTests.cs
@@ -1,7 +1,7 @@
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Moq;
+using VirtoCommerce.CustomerModule.Core;
 using VirtoCommerce.CustomerModule.Core.Model;
 using VirtoCommerce.CustomerModule.Core.Services;
 using VirtoCommerce.Platform.Core.Security;
@@ -19,7 +19,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Tests.Handlers
         private const string MembershipId = "membership1";
 
         [Fact]
-        public async Task Handle_MembershipExists_RemovesOrgFromContact_AndDeletesMembership()
+        public async Task Handle_MembershipExists_RemovesOrgFromContact_AndSetsMembershipDeleted()
         {
             // Arrange
             var contact = new Contact { Id = ContactId, Organizations = [OrgId], SecurityAccounts = [new ApplicationUser { Id = UserId }] };
@@ -52,17 +52,18 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Tests.Handlers
             // Act
             var result = await handler.Handle(command, CancellationToken.None);
 
-            // Assert
+            // Assert — the membership row is kept (soft-deleted via status), not hard-deleted
             Assert.Same(contactAggregate, result);
             Assert.DoesNotContain(OrgId, contact.Organizations);
             aggregateRepositoryMock.Verify(r => r.SaveAsync(contactAggregate), Times.Once);
             membershipServiceMock.Verify(
-                s => s.DeleteAsync(It.Is<IList<string>>(ids => ids.Count == 1 && ids[0] == MembershipId), false),
+                s => s.SetStatusAsync(MembershipId, ModuleConstants.MembershipStatuses.Deleted),
                 Times.Once);
+            membershipServiceMock.Verify(s => s.DeleteAsync(It.IsAny<System.Collections.Generic.IList<string>>(), It.IsAny<bool>()), Times.Never);
         }
 
         [Fact]
-        public async Task Handle_NoMembershipFound_DoesNotCallDelete()
+        public async Task Handle_NoMembershipFound_DoesNotCallSetStatus()
         {
             // Arrange
             var contact = new Contact { Id = ContactId, Organizations = [OrgId], SecurityAccounts = [new ApplicationUser { Id = UserId }] };
@@ -91,7 +92,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Tests.Handlers
             await handler.Handle(command, CancellationToken.None);
 
             // Assert
-            membershipServiceMock.Verify(s => s.DeleteAsync(It.IsAny<IList<string>>(), It.IsAny<bool>()), Times.Never);
+            membershipServiceMock.Verify(s => s.SetStatusAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
         }
 
         [Fact]
@@ -143,12 +144,12 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Tests.Handlers
                 Times.Once);
 
             membershipServiceMock.Verify(
-                s => s.DeleteAsync(It.Is<IList<string>>(ids => ids.Count == 1 && ids[0] == MembershipId), false),
+                s => s.SetStatusAsync(MembershipId, ModuleConstants.MembershipStatuses.Deleted),
                 Times.Once);
         }
 
         [Fact]
-        public async Task Handle_NoSecurityAccount_SkipsMembershipLookup_AndDelete()
+        public async Task Handle_NoSecurityAccount_SkipsMembershipLookup_AndSetStatus()
         {
             // Arrange — a contact without a linked user account (e.g. never registered): nothing to search for.
             var contact = new Contact { Id = ContactId, Organizations = [OrgId], SecurityAccounts = [] };
@@ -177,7 +178,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Tests.Handlers
             membershipSearchServiceMock.Verify(
                 s => s.SearchAsync(It.IsAny<OrganizationMembershipSearchCriteria>(), It.IsAny<bool>()),
                 Times.Never);
-            membershipServiceMock.Verify(s => s.DeleteAsync(It.IsAny<IList<string>>(), It.IsAny<bool>()), Times.Never);
+            membershipServiceMock.Verify(s => s.SetStatusAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
         }
     }
 }

--- a/tests/VirtoCommerce.ProfileExperienceApiModule.Tests/Handlers/RemoveMemberFromOrganizationCommandHandlerTests.cs
+++ b/tests/VirtoCommerce.ProfileExperienceApiModule.Tests/Handlers/RemoveMemberFromOrganizationCommandHandlerTests.cs
@@ -19,7 +19,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Tests.Handlers
         private const string MembershipId = "membership1";
 
         [Fact]
-        public async Task Handle_MembershipExists_RemovesOrgFromContact_AndSetsMembershipDeleted()
+        public async Task Handle_MembershipExists_KeepsOrgOnContact_AndSetsMembershipDeleted()
         {
             // Arrange
             var contact = new Contact { Id = ContactId, Organizations = [OrgId], SecurityAccounts = [new ApplicationUser { Id = UserId }] };
@@ -52,10 +52,11 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Tests.Handlers
             // Act
             var result = await handler.Handle(command, CancellationToken.None);
 
-            // Assert — the membership row is kept (soft-deleted via status), not hard-deleted
+            // Assert — the membership row is kept (soft-deleted via status), not hard-deleted, and the organization
+            // stays in Contact.Organizations so the removed member remains visible/auditable in the admin members grid.
             Assert.Same(contactAggregate, result);
-            Assert.DoesNotContain(OrgId, contact.Organizations);
-            aggregateRepositoryMock.Verify(r => r.SaveAsync(contactAggregate), Times.Once);
+            Assert.Contains(OrgId, contact.Organizations);
+            aggregateRepositoryMock.Verify(r => r.SaveAsync(It.IsAny<ContactAggregate>()), Times.Never);
             membershipServiceMock.Verify(
                 s => s.SetStatusAsync(MembershipId, ModuleConstants.MembershipStatuses.Deleted),
                 Times.Once);
@@ -174,7 +175,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Tests.Handlers
             await handler.Handle(command, CancellationToken.None);
 
             // Assert
-            Assert.DoesNotContain(OrgId, contact.Organizations);
+            Assert.Contains(OrgId, contact.Organizations);
             membershipSearchServiceMock.Verify(
                 s => s.SearchAsync(It.IsAny<OrganizationMembershipSearchCriteria>(), It.IsAny<bool>()),
                 Times.Never);

--- a/tests/VirtoCommerce.ProfileExperienceApiModule.Tests/Handlers/RemoveMemberFromOrganizationCommandHandlerTests.cs
+++ b/tests/VirtoCommerce.ProfileExperienceApiModule.Tests/Handlers/RemoveMemberFromOrganizationCommandHandlerTests.cs
@@ -95,6 +95,59 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Tests.Handlers
         }
 
         [Fact]
+        public async Task Handle_MultipleSecurityAccounts_ReusesResolvedMembership_SingleSearchCall()
+        {
+            // Arrange — the contact has two security accounts; the membership belongs to the second one.
+            // The resolver's own search already returns the membership, so Handle must reuse it instead of
+            // searching for it again by userId.
+            const string secondUserId = "user2";
+            var contact = new Contact
+            {
+                Id = ContactId,
+                Organizations = [OrgId],
+                SecurityAccounts = [new ApplicationUser { Id = UserId }, new ApplicationUser { Id = secondUserId }],
+            };
+            var contactAggregate = new ContactAggregate { Member = contact };
+
+            var aggregateRepositoryMock = new Mock<IContactAggregateRepository>();
+            aggregateRepositoryMock
+                .Setup(r => r.GetMemberAggregateRootByIdAsync<ContactAggregate>(ContactId))
+                .ReturnsAsync(contactAggregate);
+
+            var membershipSearchServiceMock = new Mock<IOrganizationMembershipSearchService>();
+            membershipSearchServiceMock
+                .Setup(s => s.SearchAsync(
+                    It.Is<OrganizationMembershipSearchCriteria>(c =>
+                        c.UserIds != null && c.UserIds.Contains(UserId) && c.UserIds.Contains(secondUserId) && c.OrganizationId == OrgId),
+                    It.IsAny<bool>()))
+                .ReturnsAsync(new OrganizationMembershipSearchResult
+                {
+                    Results = [new OrganizationMembership { Id = MembershipId, UserId = secondUserId }],
+                });
+
+            var membershipServiceMock = new Mock<IOrganizationMembershipService>();
+
+            var handler = new RemoveMemberFromOrganizationCommandHandler(
+                aggregateRepositoryMock.Object,
+                membershipServiceMock.Object,
+                membershipSearchServiceMock.Object);
+
+            var command = new RemoveMemberFromOrganizationCommand { ContactId = ContactId, OrganizationId = OrgId };
+
+            // Act
+            await handler.Handle(command, CancellationToken.None);
+
+            // Assert — exactly one search call total (the multi-account resolution search)
+            membershipSearchServiceMock.Verify(
+                s => s.SearchAsync(It.IsAny<OrganizationMembershipSearchCriteria>(), It.IsAny<bool>()),
+                Times.Once);
+
+            membershipServiceMock.Verify(
+                s => s.DeleteAsync(It.Is<IList<string>>(ids => ids.Count == 1 && ids[0] == MembershipId), false),
+                Times.Once);
+        }
+
+        [Fact]
         public async Task Handle_NoSecurityAccount_SkipsMembershipLookup_AndDelete()
         {
             // Arrange — a contact without a linked user account (e.g. never registered): nothing to search for.

--- a/tests/VirtoCommerce.ProfileExperienceApiModule.Tests/Handlers/ResendOrganizationInviteCommandHandlerTests.cs
+++ b/tests/VirtoCommerce.ProfileExperienceApiModule.Tests/Handlers/ResendOrganizationInviteCommandHandlerTests.cs
@@ -1,0 +1,111 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using VirtoCommerce.CustomerModule.Core;
+using VirtoCommerce.CustomerModule.Core.Model;
+using VirtoCommerce.CustomerModule.Core.Services;
+using VirtoCommerce.Platform.Core.Security;
+using VirtoCommerce.ProfileExperienceApiModule.Data.Aggregates.Contact;
+using VirtoCommerce.ProfileExperienceApiModule.Data.Commands;
+using Xunit;
+
+namespace VirtoCommerce.ProfileExperienceApiModule.Tests.Handlers
+{
+    public class ResendOrganizationInviteCommandHandlerTests
+    {
+        private const string MemberId = "member1";
+        private const string UserId = "user1";
+        private const string OrgId = "org1";
+        private const string MembershipId = "membership1";
+
+        [Fact]
+        public async Task Handle_ResolvesMembershipId_AndDelegatesToSharedService()
+        {
+            // Arrange
+            var contact = new Contact
+            {
+                Id = MemberId,
+                Organizations = [OrgId],
+                SecurityAccounts = [new ApplicationUser { Id = UserId }],
+            };
+            var contactAggregate = new ContactAggregate { Member = contact };
+
+            var aggregateRepositoryMock = new Mock<IContactAggregateRepository>();
+            aggregateRepositoryMock
+                .Setup(r => r.GetMemberAggregateRootByIdAsync<ContactAggregate>(MemberId))
+                .ReturnsAsync(contactAggregate);
+
+            var membershipSearchServiceMock = new Mock<IOrganizationMembershipSearchService>();
+            membershipSearchServiceMock
+                .Setup(s => s.SearchAsync(
+                    It.Is<OrganizationMembershipSearchCriteria>(c => c.UserId == UserId && c.OrganizationId == OrgId),
+                    It.IsAny<bool>()))
+                .ReturnsAsync(new OrganizationMembershipSearchResult
+                {
+                    Results = [new OrganizationMembership { Id = MembershipId, Status = ModuleConstants.MembershipStatuses.Invited }],
+                });
+
+            var inviteCustomerServiceMock = new Mock<IInviteCustomerService>();
+            inviteCustomerServiceMock
+                .Setup(s => s.ResendInviteAsync(MembershipId, "/confirm-invitation", "Reminder", It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new InviteCustomerResult { Succeeded = true, Errors = [] });
+
+            var handler = new ResendOrganizationInviteCommandHandler(
+                aggregateRepositoryMock.Object,
+                membershipSearchServiceMock.Object,
+                inviteCustomerServiceMock.Object);
+
+            var command = new ResendOrganizationInviteCommand
+            {
+                MemberId = MemberId,
+                OrganizationId = OrgId,
+                UrlSuffix = "/confirm-invitation",
+                Message = "Reminder",
+            };
+
+            // Act
+            var result = await handler.Handle(command, CancellationToken.None);
+
+            // Assert
+            Assert.True(result.Succeeded);
+            Assert.Empty(result.Errors);
+            inviteCustomerServiceMock.Verify(
+                s => s.ResendInviteAsync(MembershipId, "/confirm-invitation", "Reminder", It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task Handle_NoSecurityAccount_ReturnsUserNotFoundError()
+        {
+            // Arrange
+            var contact = new Contact { Id = MemberId, Organizations = [OrgId], SecurityAccounts = [] };
+            var contactAggregate = new ContactAggregate { Member = contact };
+
+            var aggregateRepositoryMock = new Mock<IContactAggregateRepository>();
+            aggregateRepositoryMock
+                .Setup(r => r.GetMemberAggregateRootByIdAsync<ContactAggregate>(MemberId))
+                .ReturnsAsync(contactAggregate);
+
+            var membershipSearchServiceMock = new Mock<IOrganizationMembershipSearchService>();
+            var inviteCustomerServiceMock = new Mock<IInviteCustomerService>();
+
+            var handler = new ResendOrganizationInviteCommandHandler(
+                aggregateRepositoryMock.Object,
+                membershipSearchServiceMock.Object,
+                inviteCustomerServiceMock.Object);
+
+            var command = new ResendOrganizationInviteCommand { MemberId = MemberId, OrganizationId = OrgId };
+
+            // Act
+            var result = await handler.Handle(command, CancellationToken.None);
+
+            // Assert
+            Assert.False(result.Succeeded);
+            var error = Assert.Single(result.Errors);
+            Assert.Equal("UserNotFound", error.Code);
+            inviteCustomerServiceMock.Verify(
+                s => s.ResendInviteAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+                Times.Never);
+        }
+    }
+}

--- a/tests/VirtoCommerce.ProfileExperienceApiModule.Tests/Handlers/ResendOrganizationInviteCommandHandlerTests.cs
+++ b/tests/VirtoCommerce.ProfileExperienceApiModule.Tests/Handlers/ResendOrganizationInviteCommandHandlerTests.cs
@@ -47,7 +47,9 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Tests.Handlers
 
             var inviteCustomerServiceMock = new Mock<IInviteCustomerService>();
             inviteCustomerServiceMock
-                .Setup(s => s.ResendInviteAsync(MembershipId, "/confirm-invitation", "Reminder", It.IsAny<CancellationToken>()))
+                .Setup(s => s.ResendInviteAsync(
+                    It.Is<ResendInviteRequest>(r => r.MembershipId == MembershipId && r.UrlSuffix == "/confirm-invitation" && r.Message == "Reminder"),
+                    It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new InviteCustomerResult { Succeeded = true, Errors = [] });
 
             var handler = new ResendOrganizationInviteCommandHandler(
@@ -70,8 +72,76 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Tests.Handlers
             Assert.True(result.Succeeded);
             Assert.Empty(result.Errors);
             inviteCustomerServiceMock.Verify(
-                s => s.ResendInviteAsync(MembershipId, "/confirm-invitation", "Reminder", It.IsAny<CancellationToken>()),
+                s => s.ResendInviteAsync(
+                    It.Is<ResendInviteRequest>(r => r.MembershipId == MembershipId && r.UrlSuffix == "/confirm-invitation" && r.Message == "Reminder"),
+                    It.IsAny<CancellationToken>()),
                 Times.Once);
+        }
+
+        [Fact]
+        public async Task Handle_MissingOrganizationId_ReturnsStructuredError_DoesNotThrow()
+        {
+            // Arrange — must not throw for an expected validation failure; this handler has a structured
+            // error channel (IdentityResultResponse), unlike Accept/Reject/Revoke which return ContactAggregate.
+            var handler = new ResendOrganizationInviteCommandHandler(
+                new Mock<IContactAggregateRepository>().Object,
+                new Mock<IOrganizationMembershipSearchService>().Object,
+                new Mock<IInviteCustomerService>().Object);
+
+            var command = new ResendOrganizationInviteCommand { MemberId = MemberId, OrganizationId = null };
+
+            // Act
+            var result = await handler.Handle(command, CancellationToken.None);
+
+            // Assert
+            Assert.False(result.Succeeded);
+            var error = Assert.Single(result.Errors);
+            Assert.Equal("OrganizationIdRequired", error.Code);
+        }
+
+        [Fact]
+        public async Task Handle_NoPendingInvite_ReturnsStructuredError_DoesNotThrow()
+        {
+            // Arrange — same expected-error reasoning as above: no throw, structured InviteNotFound instead.
+            var contact = new Contact
+            {
+                Id = MemberId,
+                Organizations = [OrgId],
+                SecurityAccounts = [new ApplicationUser { Id = UserId }],
+            };
+            var contactAggregate = new ContactAggregate { Member = contact };
+
+            var aggregateRepositoryMock = new Mock<IContactAggregateRepository>();
+            aggregateRepositoryMock
+                .Setup(r => r.GetMemberAggregateRootByIdAsync<ContactAggregate>(MemberId))
+                .ReturnsAsync(contactAggregate);
+
+            var membershipSearchServiceMock = new Mock<IOrganizationMembershipSearchService>();
+            membershipSearchServiceMock
+                .Setup(s => s.SearchAsync(
+                    It.Is<OrganizationMembershipSearchCriteria>(c => c.UserId == UserId && c.OrganizationId == OrgId),
+                    It.IsAny<bool>()))
+                .ReturnsAsync(new OrganizationMembershipSearchResult { Results = [] });
+
+            var inviteCustomerServiceMock = new Mock<IInviteCustomerService>();
+
+            var handler = new ResendOrganizationInviteCommandHandler(
+                aggregateRepositoryMock.Object,
+                membershipSearchServiceMock.Object,
+                inviteCustomerServiceMock.Object);
+
+            var command = new ResendOrganizationInviteCommand { MemberId = MemberId, OrganizationId = OrgId };
+
+            // Act
+            var result = await handler.Handle(command, CancellationToken.None);
+
+            // Assert
+            Assert.False(result.Succeeded);
+            var error = Assert.Single(result.Errors);
+            Assert.Equal("InviteNotFound", error.Code);
+            inviteCustomerServiceMock.Verify(
+                s => s.ResendInviteAsync(It.IsAny<ResendInviteRequest>(), It.IsAny<CancellationToken>()),
+                Times.Never);
         }
 
         [Fact]
@@ -104,7 +174,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Tests.Handlers
             var error = Assert.Single(result.Errors);
             Assert.Equal("UserNotFound", error.Code);
             inviteCustomerServiceMock.Verify(
-                s => s.ResendInviteAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+                s => s.ResendInviteAsync(It.IsAny<ResendInviteRequest>(), It.IsAny<CancellationToken>()),
                 Times.Never);
         }
     }

--- a/tests/VirtoCommerce.ProfileExperienceApiModule.Tests/Handlers/RevokeOrganizationInviteCommandHandlerTests.cs
+++ b/tests/VirtoCommerce.ProfileExperienceApiModule.Tests/Handlers/RevokeOrganizationInviteCommandHandlerTests.cs
@@ -1,0 +1,70 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using VirtoCommerce.CustomerModule.Core;
+using VirtoCommerce.CustomerModule.Core.Model;
+using VirtoCommerce.CustomerModule.Core.Services;
+using VirtoCommerce.Platform.Core.Security;
+using VirtoCommerce.ProfileExperienceApiModule.Data.Aggregates.Contact;
+using VirtoCommerce.ProfileExperienceApiModule.Data.Commands;
+using Xunit;
+
+namespace VirtoCommerce.ProfileExperienceApiModule.Tests.Handlers
+{
+    public class RevokeOrganizationInviteCommandHandlerTests
+    {
+        private const string MemberId = "member1";
+        private const string UserId = "user1";
+        private const string OrgId = "org1";
+        private const string MembershipId = "membership1";
+
+        [Fact]
+        public async Task Handle_ResolvesMembershipId_AndDelegatesToSharedService()
+        {
+            // Arrange
+            var contact = new Contact
+            {
+                Id = MemberId,
+                Organizations = [OrgId],
+                SecurityAccounts = [new ApplicationUser { Id = UserId }],
+            };
+            var contactAggregate = new ContactAggregate { Member = contact };
+
+            var aggregateRepositoryMock = new Mock<IContactAggregateRepository>();
+            aggregateRepositoryMock
+                .Setup(r => r.GetMemberAggregateRootByIdAsync<ContactAggregate>(MemberId))
+                .ReturnsAsync(contactAggregate);
+
+            var membershipSearchServiceMock = new Mock<IOrganizationMembershipSearchService>();
+            membershipSearchServiceMock
+                .Setup(s => s.SearchAsync(
+                    It.Is<OrganizationMembershipSearchCriteria>(c => c.UserId == UserId && c.OrganizationId == OrgId),
+                    It.IsAny<bool>()))
+                .ReturnsAsync(new OrganizationMembershipSearchResult
+                {
+                    Results = [new OrganizationMembership { Id = MembershipId, Status = ModuleConstants.MembershipStatuses.Invited }],
+                });
+
+            var inviteCustomerServiceMock = new Mock<IInviteCustomerService>();
+            inviteCustomerServiceMock
+                .Setup(s => s.RevokeInviteAsync(MembershipId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new InviteCustomerResult { Succeeded = true, Errors = new List<InviteCustomerError>() });
+
+            var handler = new RevokeOrganizationInviteCommandHandler(
+                aggregateRepositoryMock.Object,
+                membershipSearchServiceMock.Object,
+                inviteCustomerServiceMock.Object);
+
+            var command = new RevokeOrganizationInviteCommand { MemberId = MemberId, OrganizationId = OrgId };
+
+            // Act
+            var result = await handler.Handle(command, CancellationToken.None);
+
+            // Assert
+            Assert.Same(contactAggregate, result);
+            inviteCustomerServiceMock.Verify(s => s.RevokeInviteAsync(MembershipId, It.IsAny<CancellationToken>()), Times.Once);
+            aggregateRepositoryMock.Verify(r => r.GetMemberAggregateRootByIdAsync<ContactAggregate>(MemberId), Times.Exactly(2));
+        }
+    }
+}

--- a/tests/VirtoCommerce.ProfileExperienceApiModule.Tests/Handlers/RevokeOrganizationInviteCommandHandlerTests.cs
+++ b/tests/VirtoCommerce.ProfileExperienceApiModule.Tests/Handlers/RevokeOrganizationInviteCommandHandlerTests.cs
@@ -61,12 +61,13 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Tests.Handlers
             // Act
             var result = await handler.Handle(command, CancellationToken.None);
 
-            // Assert
+            // Assert — the organization stays in Contact.Organizations: the admin members grid is driven by this
+            // relation, so removing it here would hide the (still-auditable) revoked membership from that list.
             Assert.Same(contactAggregate, result);
-            Assert.DoesNotContain(OrgId, contact.Organizations);
+            Assert.Contains(OrgId, contact.Organizations);
             inviteCustomerServiceMock.Verify(s => s.RevokeInviteAsync(MembershipId, It.IsAny<CancellationToken>()), Times.Once);
-            aggregateRepositoryMock.Verify(r => r.GetMemberAggregateRootByIdAsync<ContactAggregate>(MemberId), Times.Exactly(2));
-            aggregateRepositoryMock.Verify(r => r.SaveAsync(contactAggregate), Times.Once);
+            aggregateRepositoryMock.Verify(r => r.GetMemberAggregateRootByIdAsync<ContactAggregate>(MemberId), Times.Once);
+            aggregateRepositoryMock.Verify(r => r.SaveAsync(It.IsAny<ContactAggregate>()), Times.Never);
         }
     }
 }

--- a/tests/VirtoCommerce.ProfileExperienceApiModule.Tests/Schemas/ContactTypeTests.cs
+++ b/tests/VirtoCommerce.ProfileExperienceApiModule.Tests/Schemas/ContactTypeTests.cs
@@ -255,6 +255,34 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Tests.Schemas
             Assert.DoesNotContain(OrgId, approvedResult);
         }
 
+        [Fact]
+        public async Task OrganizationsStatusFilter_NoExplicitStatuses_HidesBlockingStatusesByDefault()
+        {
+            // Arrange — org-1: rejected membership (should be hidden by default); org-2: approved (should show)
+            const string approvedOrgId = "org-2";
+
+            _membershipSearchServiceMock
+                .Setup(x => x.SearchAsync(It.IsAny<OrganizationMembershipSearchCriteria>(), It.IsAny<bool>()))
+                .ReturnsAsync(new OrganizationMembershipSearchResult
+                {
+                    Results =
+                    [
+                        new OrganizationMembership { UserId = "user-1", OrganizationId = OrgId, Status = ModuleConstants.MembershipStatuses.Rejected },
+                        new OrganizationMembership { UserId = "user-1", OrganizationId = approvedOrgId, Status = ModuleConstants.MembershipStatuses.Approved },
+                    ],
+                    TotalCount = 2,
+                });
+
+            var context = BuildContext(contactId: "contact-1", userId: "user-1");
+
+            // Act — no `statuses` argument at all (the raw list/connection default, e.g. a direct query with no filter)
+            var result = await InvokeResolveMyOrganizationIdsByStatusAsync(context, [OrgId, approvedOrgId], null);
+
+            // Assert
+            Assert.DoesNotContain(OrgId, result);
+            Assert.Contains(approvedOrgId, result);
+        }
+
         private async Task<IReadOnlyCollection<string>> InvokeResolveMyOrganizationIdsByStatusAsync(
             ResolveFieldContext<ContactAggregate> context, IList<string> organizationIds, IList<string> statuses)
         {

--- a/tests/VirtoCommerce.ProfileExperienceApiModule.Tests/Schemas/ContactTypeTests.cs
+++ b/tests/VirtoCommerce.ProfileExperienceApiModule.Tests/Schemas/ContactTypeTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using GraphQL;
@@ -165,6 +166,107 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Tests.Schemas
             _membershipSearchServiceMock.Verify(
                 x => x.SearchAsync(It.IsAny<OrganizationMembershipSearchCriteria>(), It.IsAny<bool>()),
                 Times.Never);
+        }
+
+        [Fact]
+        public async Task OrganizationsStatusFilter_UsesSourceContactsOwnSecurityAccount_NotCaller()
+        {
+            // Arrange — the caller (organization_id claim aside, there's no "current user" concept in this
+            // resolver anymore) must never influence the filter; only the source contact's own membership does.
+            // A membership belonging to a different user id ("other-user") must be ignored.
+            _membershipSearchServiceMock
+                .Setup(x => x.SearchAsync(
+                    It.Is<OrganizationMembershipSearchCriteria>(c =>
+                        c.UserIds.Contains("contact-owner-user") && c.OrganizationIds.Contains(OrgId)),
+                    It.IsAny<bool>()))
+                .ReturnsAsync(new OrganizationMembershipSearchResult
+                {
+                    Results = [new OrganizationMembership { UserId = "contact-owner-user", OrganizationId = OrgId, Status = ModuleConstants.MembershipStatuses.Approved }],
+                    TotalCount = 1,
+                });
+
+            _membershipSearchServiceMock
+                .Setup(x => x.SearchAsync(
+                    It.Is<OrganizationMembershipSearchCriteria>(c => c.UserIds.Contains("other-user")),
+                    It.IsAny<bool>()))
+                .ReturnsAsync(new OrganizationMembershipSearchResult
+                {
+                    Results = [new OrganizationMembership { UserId = "other-user", OrganizationId = OrgId, Status = ModuleConstants.MembershipStatuses.Rejected }],
+                    TotalCount = 1,
+                });
+
+            var context = BuildContext(contactId: "contact-1", userId: "contact-owner-user");
+
+            // Act
+            var result = await InvokeResolveMyOrganizationIdsByStatusAsync(
+                context, [OrgId], [ModuleConstants.MembershipStatuses.Approved]);
+
+            // Assert
+            Assert.Contains(OrgId, result);
+        }
+
+        [Fact]
+        public async Task OrganizationsStatusFilter_NoMembershipOverride_FallsBackToGlobalContactStatus()
+        {
+            // Arrange — no membership row at all for this org; the contact's own global status applies
+            _membershipSearchServiceMock
+                .Setup(x => x.SearchAsync(It.IsAny<OrganizationMembershipSearchCriteria>(), It.IsAny<bool>()))
+                .ReturnsAsync(new OrganizationMembershipSearchResult { Results = [], TotalCount = 0 });
+
+            var context = BuildContext(contactId: "contact-1", userId: "user-1");
+            context.Source.Contact.Status = ModuleConstants.MembershipStatuses.Rejected;
+
+            // Act
+            var approvedResult = await InvokeResolveMyOrganizationIdsByStatusAsync(
+                context, [OrgId], [ModuleConstants.MembershipStatuses.Approved]);
+            var rejectedResult = await InvokeResolveMyOrganizationIdsByStatusAsync(
+                context, [OrgId], [ModuleConstants.MembershipStatuses.Rejected]);
+
+            // Assert
+            Assert.DoesNotContain(OrgId, approvedResult);
+            Assert.Contains(OrgId, rejectedResult);
+        }
+
+        [Fact]
+        public async Task OrganizationsStatusFilter_LockedMembership_MatchesOnlyLockedFilter()
+        {
+            // Arrange
+            _membershipSearchServiceMock
+                .Setup(x => x.SearchAsync(It.IsAny<OrganizationMembershipSearchCriteria>(), It.IsAny<bool>()))
+                .ReturnsAsync(new OrganizationMembershipSearchResult
+                {
+                    Results = [new OrganizationMembership
+                    {
+                        UserId = "user-1",
+                        OrganizationId = OrgId,
+                        Status = ModuleConstants.MembershipStatuses.Approved,
+                        IsLocked = true,
+                    }],
+                    TotalCount = 1,
+                });
+
+            var context = BuildContext(contactId: "contact-1", userId: "user-1");
+
+            // Act
+            var lockedResult = await InvokeResolveMyOrganizationIdsByStatusAsync(context, [OrgId], ["Locked"]);
+            var approvedResult = await InvokeResolveMyOrganizationIdsByStatusAsync(
+                context, [OrgId], [ModuleConstants.MembershipStatuses.Approved]);
+
+            // Assert — a locked membership matches the Locked filter, not the underlying lifecycle status
+            Assert.Contains(OrgId, lockedResult);
+            Assert.DoesNotContain(OrgId, approvedResult);
+        }
+
+        private async Task<IReadOnlyCollection<string>> InvokeResolveMyOrganizationIdsByStatusAsync(
+            ResolveFieldContext<ContactAggregate> context, IList<string> organizationIds, IList<string> statuses)
+        {
+            var method = typeof(ContactType).GetMethod(
+                "ResolveMyOrganizationIdsByStatusAsync", BindingFlags.NonPublic | BindingFlags.Static);
+
+            var task = (Task<IReadOnlyCollection<string>>)method!.Invoke(
+                null, [context, _membershipSearchServiceMock.Object, organizationIds, statuses]);
+
+            return await task;
         }
 
         private async Task<List<object>> ResolveForContactsAsync(string fieldName, int count)

--- a/tests/VirtoCommerce.ProfileExperienceApiModule.Tests/Schemas/OrganizationTypeTests.cs
+++ b/tests/VirtoCommerce.ProfileExperienceApiModule.Tests/Schemas/OrganizationTypeTests.cs
@@ -1,0 +1,162 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using GraphQL;
+using GraphQL.DataLoader;
+using MediatR;
+using Microsoft.AspNetCore.Identity;
+using Moq;
+using VirtoCommerce.CustomerModule.Core;
+using VirtoCommerce.CustomerModule.Core.Model;
+using VirtoCommerce.CustomerModule.Core.Services;
+using VirtoCommerce.Platform.Core.Security;
+using VirtoCommerce.ProfileExperienceApiModule.Data.Aggregates;
+using VirtoCommerce.ProfileExperienceApiModule.Data.Aggregates.Organization;
+using VirtoCommerce.ProfileExperienceApiModule.Data.Schemas;
+using VirtoCommerce.ProfileExperienceApiModule.Data.Services;
+using VirtoCommerce.StoreModule.Core.Services;
+using VirtoCommerce.Xapi.Core.Infrastructure;
+using VirtoCommerce.Xapi.Core.Services;
+using Xunit;
+
+namespace VirtoCommerce.ProfileExperienceApiModule.Tests.Schemas
+{
+    public class OrganizationTypeTests
+    {
+        private const string UserId = "user-1";
+        private const string MemberId = "member-1";
+
+        private readonly Mock<IMemberService> _memberServiceMock = new();
+        private readonly Mock<IOrganizationMembershipSearchService> _membershipSearchServiceMock = new();
+        private readonly Mock<UserManager<ApplicationUser>> _userManagerMock;
+        private readonly OrganizationType _organizationType;
+
+        public OrganizationTypeTests()
+        {
+            ClaimsPrincipalExtensions.UserIdClaimTypes = [ClaimTypes.NameIdentifier];
+
+            _userManagerMock = new Mock<UserManager<ApplicationUser>>(
+                new Mock<IUserStore<ApplicationUser>>().Object, null, null, null, null, null, null, null, null);
+            _userManagerMock.Setup(x => x.FindByIdAsync(UserId)).ReturnsAsync(new ApplicationUser { Id = UserId, MemberId = MemberId });
+
+            var roleManagerMock = new Mock<RoleManager<Role>>(
+                new Mock<IRoleStore<Role>>().Object, null, null, null, null);
+
+            _organizationType = new OrganizationType(
+                new Mock<IStoreService>().Object,
+                new Mock<IDynamicPropertyResolverService>().Object,
+                new Mock<IMemberAddressService>().Object,
+                new Mock<IMediator>().Object,
+                new Mock<IMemberAggregateFactory>().Object,
+                _memberServiceMock.Object,
+                new Mock<IMemberSearchService>().Object,
+                _membershipSearchServiceMock.Object,
+                () => roleManagerMock.Object,
+                () => _userManagerMock.Object,
+                new DataLoaderContextAccessor { Context = new DataLoaderContext() });
+        }
+
+        [Fact]
+        public async Task MyStatusInOrganization_PageOfOrganizations_FetchesUserAndMembershipsInSingleBatch()
+        {
+            // Arrange — user has an Approved override in org-2 only; org-1 and org-3 fall back to the
+            // contact's global status.
+            _memberServiceMock
+                .Setup(x => x.GetByIdAsync(MemberId, null, null))
+                .ReturnsAsync(new Contact { Id = MemberId, Status = ModuleConstants.MembershipStatuses.Rejected });
+
+            _membershipSearchServiceMock
+                .Setup(x => x.SearchAsync(
+                    It.Is<OrganizationMembershipSearchCriteria>(c => c.UserId == UserId),
+                    It.IsAny<bool>()))
+                .ReturnsAsync(new OrganizationMembershipSearchResult
+                {
+                    Results = [new OrganizationMembership { UserId = UserId, OrganizationId = "org-2", Status = ModuleConstants.MembershipStatuses.Approved }],
+                    TotalCount = 1,
+                });
+
+            // Act — resolve the field for a page of 3 organizations, then await (triggers the batch)
+            var results = await ResolveForOrganizationsAsync(["org-1", "org-2", "org-3"]);
+
+            // Assert — a single membership search for the whole page, not one per organization
+            _memberServiceMock.Verify(x => x.GetByIdAsync(MemberId, null, null), Times.Once);
+            _membershipSearchServiceMock.Verify(
+                x => x.SearchAsync(
+                    It.Is<OrganizationMembershipSearchCriteria>(c =>
+                        c.UserId == UserId && c.OrganizationIds.Count == 3),
+                    It.IsAny<bool>()),
+                Times.Once);
+
+            Assert.Equal(
+                [ModuleConstants.MembershipStatuses.Rejected, ModuleConstants.MembershipStatuses.Approved, ModuleConstants.MembershipStatuses.Rejected],
+                results);
+        }
+
+        [Fact]
+        public async Task MyStatusInOrganization_NoCurrentUser_ReturnsNull_WithoutQuerying()
+        {
+            // Arrange — no organization_id/user claim on the caller (e.g. anonymous)
+            var context = BuildContext("org-1", userId: null);
+
+            // Act
+            var result = await ResolveFieldAsync(context);
+
+            // Assert
+            Assert.Null(result);
+            _membershipSearchServiceMock.Verify(
+                x => x.SearchAsync(It.IsAny<OrganizationMembershipSearchCriteria>(), It.IsAny<bool>()),
+                Times.Never);
+        }
+
+        private async Task<List<object>> ResolveForOrganizationsAsync(IList<string> organizationIds)
+        {
+            var field = _organizationType.Fields.First(f => f.Name == "myStatusInOrganization");
+
+            var pendingResults = new List<object>();
+            foreach (var orgId in organizationIds)
+            {
+                pendingResults.Add(await field.Resolver.ResolveAsync(BuildContext(orgId, UserId)));
+            }
+
+            var results = new List<object>();
+            foreach (var pendingResult in pendingResults)
+            {
+                results.Add(await UnwrapAsync(pendingResult));
+            }
+
+            return results;
+        }
+
+        private async Task<object> ResolveFieldAsync(ResolveFieldContext<OrganizationAggregate> context)
+        {
+            var field = _organizationType.Fields.First(f => f.Name == "myStatusInOrganization");
+            var pendingResult = await field.Resolver.ResolveAsync(context);
+
+            return await UnwrapAsync(pendingResult);
+        }
+
+        private static async Task<object> UnwrapAsync(object pendingResult)
+        {
+            var dataLoaderResult = Assert.IsType<IDataLoaderResult>(pendingResult, exactMatch: false);
+
+            return await dataLoaderResult.GetResultAsync();
+        }
+
+        private static ResolveFieldContext<OrganizationAggregate> BuildContext(string organizationId, string userId) =>
+            new()
+            {
+                Source = new OrganizationAggregate { Member = new Organization { Id = organizationId } },
+                UserContext = new GraphQLUserContext(BuildPrincipal(userId)),
+            };
+
+        private static ClaimsPrincipal BuildPrincipal(string userId)
+        {
+            var claims = string.IsNullOrEmpty(userId)
+                ? []
+                : new[] { new Claim(ClaimTypes.NameIdentifier, userId) };
+
+            return new ClaimsPrincipal(new ClaimsIdentity(claims));
+        }
+    }
+}


### PR DESCRIPTION
## Description

### New mutations

* acceptOrganizationInvite	Invitee accepts an invitation
* rejectOrganizationInvite	Invitee declines; the organization is removed from the contact
* revokeOrganizationInvite	Org admin cancels a pending invitation
* resendOrganizationInvite	Org admin re-sends the invitation email

> inviteUser keeps its contract but now delegates to IInviteCustomerService.

### New schema surface

* OrganizationType.myStatusInOrganization — the current user's effective status in that organization, resolved through a batch loader.
* ContactType.statusInOrganization — a contact's effective status in the current organization, batched.
statuses argument on organization and contact-organization connections, including the synthetic Locked filter value alongside the real statuses.
* Dedicated input types InputRevokeOrganizationInviteType and InputResendOrganizationInviteType (the latter's urlSuffix is optional and typed as nullable).

### Behaviour

* ProfileAuthorizationHandler applies the effective-status and lock check to the OrganizationAggregate branch, so a rejected, revoked, or blocked user can no longer read organization contacts and addresses through the organization query.
* Registering by invitation approves the corresponding invited memberships in a single batched save.
* Removing a member from an organization deletes the membership row and triggers token revocation.
* ContactSecurityAccountResolverExtensions.ResolveMembershipForOrganizationAsync resolves the right membership for contacts holding more than one security account, replacing the previous "first account wins" shortcut.

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5281
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.ProfileExperienceApiModule_3.1015.0-pr-141-2bcd.zip