### PR TITLE
feat: make organization contact lock/unlock step overridable

### DIFF
--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/LockOrganizationContactCommandHandler.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/LockOrganizationContactCommandHandler.cs
@@ -25,6 +25,8 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
             _organizationMembershipSearchService = organizationMembershipSearchService;
         }
 
+        protected IContactAggregateRepository ContactAggregateRepository => _contactAggregateRepository;
+
         public virtual async Task<ContactAggregate> Handle(LockOrganizationContactCommand request, CancellationToken cancellationToken)
         {
             if (string.IsNullOrEmpty(request.OrganizationId))
@@ -41,6 +43,13 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
                 return contactAggregate;
             }
 
+            await ApplyLockAsync(contactAggregate, userId, request, cancellationToken);
+
+            return contactAggregate;
+        }
+
+        protected virtual async Task ApplyLockAsync(ContactAggregate contactAggregate, string userId, LockOrganizationContactCommand request, CancellationToken cancellationToken)
+        {
             var searchResult = await _organizationMembershipSearchService.SearchAsync(
                 new OrganizationMembershipSearchCriteria
                 {
@@ -53,8 +62,6 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
                 ?? throw new InvalidOperationException($"Contact '{request.MemberId}' has no membership in organization '{request.OrganizationId}'.");
 
             await _organizationMembershipService.LockAsync(membership.Id);
-
-            return contactAggregate;
         }
     }
 }

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/UnlockOrganizationContactCommandHandler.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/UnlockOrganizationContactCommandHandler.cs
@@ -25,6 +25,8 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
             _organizationMembershipSearchService = organizationMembershipSearchService;
         }
 
+        protected IContactAggregateRepository ContactAggregateRepository => _contactAggregateRepository;
+
         public virtual async Task<ContactAggregate> Handle(UnlockOrganizationContactCommand request, CancellationToken cancellationToken)
         {
             if (string.IsNullOrEmpty(request.OrganizationId))
@@ -41,6 +43,13 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
                 return contactAggregate;
             }
 
+            await ApplyUnlockAsync(contactAggregate, userId, request, cancellationToken);
+
+            return contactAggregate;
+        }
+
+        protected virtual async Task ApplyUnlockAsync(ContactAggregate contactAggregate, string userId, UnlockOrganizationContactCommand request, CancellationToken cancellationToken)
+        {
             var searchResult = await _organizationMembershipSearchService.SearchAsync(
                 new OrganizationMembershipSearchCriteria
                 {
@@ -53,8 +62,6 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
                 ?? throw new InvalidOperationException($"Contact '{request.MemberId}' has no membership in organization '{request.OrganizationId}'.");
 
             await _organizationMembershipService.UnlockAsync(membership.Id);
-
-            return contactAggregate;
         }
     }
 }


### PR DESCRIPTION
## Why

`LockOrganizationContactCommandHandler` / `UnlockOrganizationContactCommandHandler` hardwire the lock/unlock effect to a single policy: resolve the user's `OrganizationMembership` in the requested organization and lock/unlock it, throwing `InvalidOperationException` when the user has no membership in that organization.

A consumer that needs a different policy (for example, locking at a scope other than a single per-organization membership) currently has to override `Handle` and reimplement the entire method — the `OrganizationId` guard, the aggregate load, the security-account resolution and early return — only to change the final step. That duplicated preamble silently drifts out of sync with the base whenever the shared logic changes.

## What changed

- Extracted the membership resolution + `LockAsync` / `UnlockAsync` step out of `Handle` into a `protected virtual ApplyLockAsync` / `ApplyUnlockAsync(ContactAggregate contactAggregate, string userId, <Command> request, CancellationToken)`. `Handle` keeps the shared preamble and calls the seam.
- Exposed the aggregate repository to subclasses via `protected IContactAggregateRepository ContactAggregateRepository`, so an override can persist changes without re-injecting the dependency.

## Behavior

Default behavior is byte-for-byte unchanged, including the exact exception message (the whole `request` is passed into the seam). `Handle` stays `virtual`; constructors and DI registration are untouched. The existing handler tests — the default-behavior regression guard, including the membership-not-found throw case — pass unchanged.
Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.ProfileExperienceApiModule_3.1013.0-pr-142-4501.zip