### PR TITLE
VCST-5450: Made company member roles configurable per store

### DIFF
--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/ChangeOrganizationContactRoleCommand.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/ChangeOrganizationContactRoleCommand.cs
@@ -8,6 +8,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
         public string MemberId { get; set; }
         public string OrganizationId { get; set; }
         public string StoreId { get; set; }
+        public string CultureName { get; set; }
         public string[] RoleIds { get; set; }
     }
 }

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/ChangeOrganizationContactRoleCommand.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/ChangeOrganizationContactRoleCommand.cs
@@ -1,5 +1,5 @@
-using VirtoCommerce.Xapi.Core.Infrastructure;
 using VirtoCommerce.ProfileExperienceApiModule.Data.Queries;
+using VirtoCommerce.Xapi.Core.Infrastructure;
 
 namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
 {
@@ -7,6 +7,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
     {
         public string MemberId { get; set; }
         public string OrganizationId { get; set; }
+        public string StoreId { get; set; }
         public string[] RoleIds { get; set; }
     }
 }

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/ChangeOrganizationContactRoleCommandHandler.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/ChangeOrganizationContactRoleCommandHandler.cs
@@ -66,13 +66,17 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
                 return result;
             }
 
-            var user = await ValidateUserEditable(userId, result);
-            if (user == null)
+            if (!await ValidateUserEditable(userId, result))
             {
                 return result;
             }
 
-            var storeId = string.IsNullOrEmpty(request.StoreId) ? user.StoreId : request.StoreId;
+            var storeId = request.StoreId;
+            if (string.IsNullOrEmpty(storeId))
+            {
+                storeId = await GetUserStoreIdAsync(userId);
+            }
+
             var roles = await ResolveRoles(request.RoleIds, storeId, result);
 
             if (result.Errors.Count > 0)
@@ -107,17 +111,24 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
             return _organizationMembershipSearchService.ResolveMembershipForOrganizationAsync(contactAggregate.Contact, organizationId);
         }
 
-        protected virtual async Task<ApplicationUser> ValidateUserEditable(string userId, IdentityResultResponse result)
+        protected virtual async Task<bool> ValidateUserEditable(string userId, IdentityResultResponse result)
         {
             using var userManager = _userManagerFactory();
             var user = await userManager.FindByIdAsync(userId);
             if (user == null || !IsUserEditable(user.UserName))
             {
                 result.Errors.Add(new IdentityErrorInfo { Code = "Forbidden", Description = "It is forbidden to edit this user." });
-                return null;
+                return false;
             }
 
-            return user;
+            return true;
+        }
+
+        private async Task<string> GetUserStoreIdAsync(string userId)
+        {
+            using var userManager = _userManagerFactory();
+            var user = await userManager.FindByIdAsync(userId);
+            return user?.StoreId;
         }
 
         protected virtual async Task<IList<Role>> ResolveRoles(string[] roleIds, string storeId, IdentityResultResponse result)

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/ChangeOrganizationContactRoleCommandHandler.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Commands/ChangeOrganizationContactRoleCommandHandler.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Options;
 using VirtoCommerce.CustomerModule.Core.Extensions;
 using VirtoCommerce.CustomerModule.Core.Model;
 using VirtoCommerce.CustomerModule.Core.Services;
+using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Platform.Core.Security;
 using VirtoCommerce.ProfileExperienceApiModule.Data.Aggregates.Contact;
 using VirtoCommerce.ProfileExperienceApiModule.Data.Models;
@@ -22,6 +23,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
         private readonly IOrganizationMembershipService _organizationMembershipService;
         private readonly IOrganizationMembershipSearchService _organizationMembershipSearchService;
         private readonly IContactAggregateRepository _contactAggregateRepository;
+        private readonly ICompanyMemberRoleService _companyMemberRoleService;
 
         public ChangeOrganizationContactRoleCommandHandler(
             Func<UserManager<ApplicationUser>> userManager,
@@ -29,6 +31,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
             IOrganizationMembershipService organizationMembershipService,
             IOrganizationMembershipSearchService organizationMembershipSearchService,
             IContactAggregateRepository contactAggregateRepository,
+            ICompanyMemberRoleService companyMemberRoleService,
             IOptions<AuthorizationOptions> securityOptions)
             : base(userManager, securityOptions)
         {
@@ -36,6 +39,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
             _organizationMembershipService = organizationMembershipService;
             _organizationMembershipSearchService = organizationMembershipSearchService;
             _contactAggregateRepository = contactAggregateRepository;
+            _companyMemberRoleService = companyMemberRoleService;
         }
 
         public virtual async Task<IdentityResultResponse> Handle(ChangeOrganizationContactRoleCommand request, CancellationToken cancellationToken)
@@ -62,12 +66,15 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
                 return result;
             }
 
-            if (!await ValidateUserEditable(userId, result))
+            var user = await ValidateUserEditable(userId, result);
+            if (user == null)
             {
                 return result;
             }
 
-            var roles = await ResolveRoles(request.RoleIds, result);
+            var storeId = string.IsNullOrEmpty(request.StoreId) ? user.StoreId : request.StoreId;
+            var roles = await ResolveRoles(request.RoleIds, storeId, result);
+
             if (result.Errors.Count > 0)
             {
                 return result;
@@ -100,34 +107,46 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Commands
             return _organizationMembershipSearchService.ResolveMembershipForOrganizationAsync(contactAggregate.Contact, organizationId);
         }
 
-        protected virtual async Task<bool> ValidateUserEditable(string userId, IdentityResultResponse result)
+        protected virtual async Task<ApplicationUser> ValidateUserEditable(string userId, IdentityResultResponse result)
         {
             using var userManager = _userManagerFactory();
             var user = await userManager.FindByIdAsync(userId);
             if (user == null || !IsUserEditable(user.UserName))
             {
                 result.Errors.Add(new IdentityErrorInfo { Code = "Forbidden", Description = "It is forbidden to edit this user." });
-                return false;
+                return null;
             }
 
-            return true;
+            return user;
         }
 
-        protected virtual async Task<IList<Role>> ResolveRoles(string[] roleIds, IdentityResultResponse result)
+        protected virtual async Task<IList<Role>> ResolveRoles(string[] roleIds, string storeId, IdentityResultResponse result)
         {
+            if (roleIds.IsNullOrEmpty())
+            {
+                return [];
+            }
+
+            var allowedRoleIds = await _companyMemberRoleService.GetAllowedRoleIdsAsync(storeId);
+
             using var roleManager = _roleManagerFactory();
             var roles = new List<Role>();
-            foreach (var roleId in roleIds ?? [])
+            foreach (var roleId in roleIds)
             {
                 var role = await roleManager.FindByIdAsync(roleId) ?? await roleManager.FindByNameAsync(roleId);
-                if (role != null)
-                {
-                    roles.Add(role);
-                }
-                else
+                if (role == null)
                 {
                     result.Errors.Add(new IdentityErrorInfo { Code = "Role not found", Description = $"Role '{roleId}' not found", Parameter = roleId });
+                    continue;
                 }
+
+                if (!allowedRoleIds.IsRoleAllowed(role))
+                {
+                    result.Errors.Add(new IdentityErrorInfo { Code = "RoleNotAllowed", Description = $"Role '{roleId}' is not allowed for company members of this store", Parameter = roleId });
+                    continue;
+                }
+
+                roles.Add(role);
             }
 
             return roles;

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Queries/ContactIdFilterResult.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Queries/ContactIdFilterResult.cs
@@ -11,5 +11,5 @@ public class ContactIdFilterResult
 {
     public bool FilterRequired { get; set; }
 
-    public IReadOnlyCollection<string> Ids { get; set; } = [];
+    public IList<string> Ids { get; set; } = [];
 }

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Queries/ContactIdFilterResult.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Queries/ContactIdFilterResult.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+
+namespace VirtoCommerce.ProfileExperienceApiModule.Data.Queries;
+
+/// <summary>
+/// Result of resolving a members-list filter (role or status) down to the set of matching contact
+/// ids. <see cref="FilterRequired"/> is false when the filter can be skipped entirely (e.g. every
+/// requested role is already an organization-level role, satisfied by every member).
+/// </summary>
+public class ContactIdFilterResult
+{
+    public bool FilterRequired { get; set; }
+
+    public IReadOnlyCollection<string> Ids { get; set; } = [];
+}

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Queries/GetOrganizationContactRolesQuery/GetOrganizationContactRolesQuery.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Queries/GetOrganizationContactRolesQuery/GetOrganizationContactRolesQuery.cs
@@ -11,4 +11,6 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Queries;
 public class GetOrganizationContactRolesQuery : IQuery<IList<Role>>
 {
     public string OrganizationId { get; set; }
+    public string StoreId { get; set; }
+    public string CultureName { get; set; }
 }

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Queries/GetOrganizationContactRolesQuery/GetOrganizationContactRolesQuery.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Queries/GetOrganizationContactRolesQuery/GetOrganizationContactRolesQuery.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+using VirtoCommerce.Platform.Core.Security;
+using VirtoCommerce.Xapi.Core.Infrastructure;
+
+namespace VirtoCommerce.ProfileExperienceApiModule.Data.Queries;
+
+/// <summary>
+/// Distinct roles currently assigned to at least one member of an organization - membership roles,
+/// organization-level roles, and members' global (account-level) roles alike.
+/// </summary>
+public class GetOrganizationContactRolesQuery : IQuery<IList<Role>>
+{
+    public string OrganizationId { get; set; }
+}

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Queries/GetOrganizationContactRolesQuery/GetOrganizationContactRolesQueryHandler.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Queries/GetOrganizationContactRolesQuery/GetOrganizationContactRolesQueryHandler.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Identity;
+using VirtoCommerce.CustomerModule.Core.Model;
+using VirtoCommerce.CustomerModule.Core.Model.Search;
+using VirtoCommerce.CustomerModule.Core.Services;
+using VirtoCommerce.Platform.Core.Common;
+using VirtoCommerce.Platform.Core.Security;
+using VirtoCommerce.ProfileExperienceApiModule.Data.Services;
+using VirtoCommerce.Xapi.Core.Infrastructure;
+
+namespace VirtoCommerce.ProfileExperienceApiModule.Data.Queries;
+
+public class GetOrganizationContactRolesQueryHandler : IQueryHandler<GetOrganizationContactRolesQuery, IList<Role>>
+{
+    private readonly IMemberService _memberService;
+    private readonly IMemberSearchService _memberSearchService;
+    private readonly IOrganizationMembershipSearchService _organizationMembershipService;
+    private readonly Func<RoleManager<Role>> _roleManagerFactory;
+    private readonly Func<UserManager<ApplicationUser>> _userManagerFactory;
+
+    public GetOrganizationContactRolesQueryHandler(
+        IMemberService memberService,
+        IMemberSearchService memberSearchService,
+        IOrganizationMembershipSearchService organizationMembershipService,
+        Func<RoleManager<Role>> roleManagerFactory,
+        Func<UserManager<ApplicationUser>> userManagerFactory)
+    {
+        _memberService = memberService;
+        _memberSearchService = memberSearchService;
+        _organizationMembershipService = organizationMembershipService;
+        _roleManagerFactory = roleManagerFactory;
+        _userManagerFactory = userManagerFactory;
+    }
+
+    public virtual async Task<IList<Role>> Handle(GetOrganizationContactRolesQuery request, CancellationToken cancellationToken)
+    {
+        var orgId = request.OrganizationId;
+
+        var membershipsTask = _organizationMembershipService.SearchAllNoCloneAsync(
+            new OrganizationMembershipSearchCriteria { OrganizationId = orgId });
+        var contactsTask = _memberSearchService.SearchAllAsync(
+            new MembersSearchCriteria { MemberId = orgId });
+        var organizationTask = _memberService.GetByIdAsync(orgId, memberType: nameof(Organization));
+
+        await Task.WhenAll(membershipsTask, contactsTask, organizationTask);
+
+        var allOrgMemberships = membershipsTask.Result;
+
+        var membershipRoles = allOrgMemberships
+            .SelectMany(m => m.Roles ?? [])
+            .Where(r => !string.IsNullOrEmpty(r.RoleId))
+            .Select(r => new Role { Id = r.RoleId, Name = r.RoleName });
+
+        var organization = organizationTask.Result as Organization;
+        var orgLevelRoles = (organization?.Roles ?? [])
+            .Where(r => !string.IsNullOrEmpty(r.RoleId))
+            .Select(r => new Role { Id = r.RoleId, Name = r.RoleName });
+
+        var orgUsers = await OrganizationUsersResolver.GetOrganizationUsersAsync(
+            allOrgMemberships, contactsTask.Result, _userManagerFactory);
+
+        var globalRolesByUser = await GlobalRolesResolver.GetGlobalRolesByUserAsync(
+            orgUsers.Select(u => u.Id).ToList(), _roleManagerFactory, _userManagerFactory);
+        var globalRoles = globalRolesByUser.Values.SelectMany(r => r);
+
+        return membershipRoles
+            .Concat(orgLevelRoles)
+            .Concat(globalRoles)
+            .GroupBy(r => r.Id, StringComparer.OrdinalIgnoreCase)
+            .Select(g => g.First())
+            .ToList();
+    }
+}

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Queries/ResolveOrganizationRoleFilterQuery/ResolveOrganizationRoleFilterQuery.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Queries/ResolveOrganizationRoleFilterQuery/ResolveOrganizationRoleFilterQuery.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+using VirtoCommerce.Xapi.Core.Infrastructure;
+
+namespace VirtoCommerce.ProfileExperienceApiModule.Data.Queries;
+
+/// <summary>
+/// Resolves a members-list "roleIds" filter (org-level, membership, or global role ids/names) down
+/// to the set of matching contact ids for an organization.
+/// </summary>
+public class ResolveOrganizationRoleFilterQuery : IQuery<ContactIdFilterResult>
+{
+    public string OrganizationId { get; set; }
+
+    public IList<string> RoleIds { get; set; }
+}

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Queries/ResolveOrganizationRoleFilterQuery/ResolveOrganizationRoleFilterQuery.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Queries/ResolveOrganizationRoleFilterQuery/ResolveOrganizationRoleFilterQuery.cs
@@ -12,4 +12,6 @@ public class ResolveOrganizationRoleFilterQuery : IQuery<ContactIdFilterResult>
     public string OrganizationId { get; set; }
 
     public IList<string> RoleIds { get; set; }
+    public string StoreId { get; set; }
+    public string CultureName { get; set; }
 }

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Queries/ResolveOrganizationRoleFilterQuery/ResolveOrganizationRoleFilterQueryHandler.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Queries/ResolveOrganizationRoleFilterQuery/ResolveOrganizationRoleFilterQueryHandler.cs
@@ -87,12 +87,12 @@ public class ResolveOrganizationRoleFilterQueryHandler : IQueryHandler<ResolveOr
                 .Select(u => u.MemberId ?? u.Id)
                 .Where(id => !string.IsNullOrEmpty(id)));
 
-        return new ContactIdFilterResult { FilterRequired = true, Ids = qualifyingContactIds };
+        return new ContactIdFilterResult { FilterRequired = true, Ids = qualifyingContactIds.ToList() };
     }
 
-    private static async Task<IReadOnlyCollection<string>> GetContactIdsByGlobalRolesAsync(
+    private static async Task<IList<string>> GetContactIdsByGlobalRolesAsync(
         IList<string> roleIds,
-        IReadOnlyCollection<ApplicationUser> orgUsers,
+        IList<ApplicationUser> orgUsers,
         RoleManager<Role> roleManager,
         UserManager<ApplicationUser> userManager)
     {

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Queries/ResolveOrganizationRoleFilterQuery/ResolveOrganizationRoleFilterQueryHandler.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Queries/ResolveOrganizationRoleFilterQuery/ResolveOrganizationRoleFilterQueryHandler.cs
@@ -1,0 +1,128 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using VirtoCommerce.CustomerModule.Core.Model;
+using VirtoCommerce.CustomerModule.Core.Model.Search;
+using VirtoCommerce.CustomerModule.Core.Services;
+using VirtoCommerce.Platform.Core.Common;
+using VirtoCommerce.Platform.Core.Security;
+using VirtoCommerce.ProfileExperienceApiModule.Data.Services;
+using VirtoCommerce.Xapi.Core.Infrastructure;
+
+namespace VirtoCommerce.ProfileExperienceApiModule.Data.Queries;
+
+public class ResolveOrganizationRoleFilterQueryHandler : IQueryHandler<ResolveOrganizationRoleFilterQuery, ContactIdFilterResult>
+{
+    private readonly IMemberService _memberService;
+    private readonly IMemberSearchService _memberSearchService;
+    private readonly IOrganizationMembershipSearchService _organizationMembershipService;
+    private readonly Func<RoleManager<Role>> _roleManagerFactory;
+    private readonly Func<UserManager<ApplicationUser>> _userManagerFactory;
+
+    public ResolveOrganizationRoleFilterQueryHandler(
+        IMemberService memberService,
+        IMemberSearchService memberSearchService,
+        IOrganizationMembershipSearchService organizationMembershipService,
+        Func<RoleManager<Role>> roleManagerFactory,
+        Func<UserManager<ApplicationUser>> userManagerFactory)
+    {
+        _memberService = memberService;
+        _memberSearchService = memberSearchService;
+        _organizationMembershipService = organizationMembershipService;
+        _roleManagerFactory = roleManagerFactory;
+        _userManagerFactory = userManagerFactory;
+    }
+
+    public virtual async Task<ContactIdFilterResult> Handle(ResolveOrganizationRoleFilterQuery request, CancellationToken cancellationToken)
+    {
+        var orgId = request.OrganizationId;
+        var roleIds = request.RoleIds;
+
+        var roleIdsSet = roleIds.ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        var organization = await _memberService.GetByIdAsync(orgId, memberType: nameof(Organization)) as Organization;
+        var orgRoleIdentifiers = organization?.Roles?
+            .SelectMany(r => new[] { r.RoleId, r.RoleName })
+            .Where(x => !string.IsNullOrEmpty(x))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase) ?? [];
+
+        if (roleIdsSet.Overlaps(orgRoleIdentifiers))
+        {
+            return new ContactIdFilterResult { FilterRequired = false };
+        }
+
+        var membershipsTask = _organizationMembershipService.SearchAllNoCloneAsync(
+            new OrganizationMembershipSearchCriteria { OrganizationId = orgId });
+        var contactsTask = _memberSearchService.SearchAllAsync(
+            new MembersSearchCriteria { MemberId = orgId });
+
+        await Task.WhenAll(membershipsTask, contactsTask);
+
+        var allOrgMemberships = membershipsTask.Result;
+        var orgUsers = await OrganizationUsersResolver.GetOrganizationUsersAsync(
+            allOrgMemberships, contactsTask.Result, _userManagerFactory);
+
+        if (orgUsers.Count == 0)
+        {
+            return new ContactIdFilterResult { FilterRequired = true };
+        }
+
+        var membershipUserIds = allOrgMemberships
+            .Where(m => m.Roles?.Any(r => roleIdsSet.Contains(r.RoleId) || roleIdsSet.Contains(r.RoleName)) == true)
+            .Select(m => m.UserId)
+            .ToHashSet();
+
+        using var globalRoleManager = _roleManagerFactory();
+        using var globalUserManager = _userManagerFactory();
+        var qualifyingContactIds = (await GetContactIdsByGlobalRolesAsync(roleIds, orgUsers, globalRoleManager, globalUserManager))
+            .ToHashSet();
+
+        qualifyingContactIds.UnionWith(
+            orgUsers
+                .Where(u => membershipUserIds.Contains(u.Id))
+                .Select(u => u.MemberId ?? u.Id)
+                .Where(id => !string.IsNullOrEmpty(id)));
+
+        return new ContactIdFilterResult { FilterRequired = true, Ids = qualifyingContactIds };
+    }
+
+    private static async Task<IReadOnlyCollection<string>> GetContactIdsByGlobalRolesAsync(
+        IList<string> roleIds,
+        IReadOnlyCollection<ApplicationUser> orgUsers,
+        RoleManager<Role> roleManager,
+        UserManager<ApplicationUser> userManager)
+    {
+        var roleIdsUpper = roleIds.Select(x => x.ToUpper()).ToList();
+        var requestedRoleNames = await roleManager.Roles
+            .Where(r => roleIdsUpper.Contains(r.Id.ToUpper()) || roleIdsUpper.Contains(r.Name.ToUpper()))
+            .Select(r => r.Name)
+            .ToListAsync();
+
+        if (requestedRoleNames.Count == 0)
+        {
+            return [];
+        }
+
+        var requestedRoleNameSet = requestedRoleNames.ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var result = new List<string>();
+
+        foreach (var user in orgUsers)
+        {
+            var userRoleNames = await userManager.GetRolesAsync(user);
+            if (userRoleNames.Any(requestedRoleNameSet.Contains))
+            {
+                var contactId = user.MemberId ?? user.Id;
+                if (!string.IsNullOrEmpty(contactId))
+                {
+                    result.Add(contactId);
+                }
+            }
+        }
+
+        return result;
+    }
+}

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Queries/ResolveOrganizationStatusFilterQuery/ResolveOrganizationStatusFilterQuery.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Queries/ResolveOrganizationStatusFilterQuery/ResolveOrganizationStatusFilterQuery.cs
@@ -12,4 +12,6 @@ public class ResolveOrganizationStatusFilterQuery : IQuery<ContactIdFilterResult
     public string OrganizationId { get; set; }
 
     public IList<string> Statuses { get; set; }
+    public string StoreId { get; set; }
+    public string CultureName { get; set; }
 }

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Queries/ResolveOrganizationStatusFilterQuery/ResolveOrganizationStatusFilterQuery.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Queries/ResolveOrganizationStatusFilterQuery/ResolveOrganizationStatusFilterQuery.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+using VirtoCommerce.Xapi.Core.Infrastructure;
+
+namespace VirtoCommerce.ProfileExperienceApiModule.Data.Queries;
+
+/// <summary>
+/// Resolves a members-list "statuses" filter (effective status/lock state, e.g. Approved, Invited,
+/// Locked) down to the set of matching contact ids for an organization.
+/// </summary>
+public class ResolveOrganizationStatusFilterQuery : IQuery<ContactIdFilterResult>
+{
+    public string OrganizationId { get; set; }
+
+    public IList<string> Statuses { get; set; }
+}

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Queries/ResolveOrganizationStatusFilterQuery/ResolveOrganizationStatusFilterQueryHandler.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Queries/ResolveOrganizationStatusFilterQuery/ResolveOrganizationStatusFilterQueryHandler.cs
@@ -1,0 +1,92 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using VirtoCommerce.CustomerModule.Core.Model;
+using VirtoCommerce.CustomerModule.Core.Model.Search;
+using VirtoCommerce.CustomerModule.Core.Services;
+using VirtoCommerce.Platform.Core.Common;
+using VirtoCommerce.Platform.Core.Security;
+using VirtoCommerce.Xapi.Core.Infrastructure;
+
+namespace VirtoCommerce.ProfileExperienceApiModule.Data.Queries;
+
+public class ResolveOrganizationStatusFilterQueryHandler : IQueryHandler<ResolveOrganizationStatusFilterQuery, ContactIdFilterResult>
+{
+    private const string LockedFilterValue = "Locked";
+
+    private readonly IMemberSearchService _memberSearchService;
+    private readonly IOrganizationMembershipSearchService _organizationMembershipService;
+
+    public ResolveOrganizationStatusFilterQueryHandler(
+        IMemberSearchService memberSearchService,
+        IOrganizationMembershipSearchService organizationMembershipService)
+    {
+        _memberSearchService = memberSearchService;
+        _organizationMembershipService = organizationMembershipService;
+    }
+
+    public virtual async Task<ContactIdFilterResult> Handle(ResolveOrganizationStatusFilterQuery request, CancellationToken cancellationToken)
+    {
+        var orgId = request.OrganizationId;
+        var statuses = request.Statuses;
+
+        var membershipsTask = _organizationMembershipService.SearchAllNoCloneAsync(
+            new OrganizationMembershipSearchCriteria { OrganizationId = orgId });
+        var contactsTask = _memberSearchService.SearchAllAsync(
+            new MembersSearchCriteria { MemberId = orgId });
+
+        await Task.WhenAll(membershipsTask, contactsTask);
+
+        var membershipByUserId = membershipsTask.Result
+            .GroupBy(m => m.UserId)
+            .ToDictionary(g => g.Key, g => g.First());
+
+        var wantsLocked = statuses.Contains(LockedFilterValue);
+        var lifecycleStatuses = statuses.Where(s => s != LockedFilterValue).ToHashSet();
+
+        var qualifyingContactIds = contactsTask.Result
+            .Where(contact => ContactMatchesStatusFilter(contact, membershipByUserId, wantsLocked, lifecycleStatuses))
+            .Select(contact => contact.Id)
+            .ToHashSet();
+
+        return new ContactIdFilterResult { FilterRequired = true, Ids = qualifyingContactIds };
+    }
+
+    private static bool ContactMatchesStatusFilter(
+        Member contact, IDictionary<string, OrganizationMembership> membershipByUserId, bool wantsLocked, HashSet<string> lifecycleStatuses)
+    {
+        var membership = FindMembership(contact, membershipByUserId);
+
+        if (membership?.IsCurrentlyLocked == true)
+        {
+            return wantsLocked;
+        }
+
+        if (lifecycleStatuses.Count == 0)
+        {
+            return false;
+        }
+
+        var effectiveStatus = OrganizationMembership.ResolveEffectiveStatus(membership?.Status, contact.Status);
+
+        return !string.IsNullOrEmpty(effectiveStatus) && lifecycleStatuses.Contains(effectiveStatus);
+    }
+
+    private static OrganizationMembership FindMembership(Member contact, IDictionary<string, OrganizationMembership> membershipByUserId)
+    {
+        var securityAccountIds = (contact as IHasSecurityAccounts)?.SecurityAccounts?
+            .Select(sa => sa.Id)
+            .Where(id => !string.IsNullOrEmpty(id)) ?? [];
+
+        foreach (var securityAccountId in securityAccountIds)
+        {
+            if (membershipByUserId.TryGetValue(securityAccountId, out var membership))
+            {
+                return membership;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Queries/ResolveOrganizationStatusFilterQuery/ResolveOrganizationStatusFilterQueryHandler.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Queries/ResolveOrganizationStatusFilterQuery/ResolveOrganizationStatusFilterQueryHandler.cs
@@ -48,7 +48,7 @@ public class ResolveOrganizationStatusFilterQueryHandler : IQueryHandler<Resolve
         var qualifyingContactIds = contactsTask.Result
             .Where(contact => ContactMatchesStatusFilter(contact, membershipByUserId, wantsLocked, lifecycleStatuses))
             .Select(contact => contact.Id)
-            .ToHashSet();
+            .ToList();
 
         return new ContactIdFilterResult { FilterRequired = true, Ids = qualifyingContactIds };
     }

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Schemas/ContactType.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Schemas/ContactType.cs
@@ -357,7 +357,7 @@ public class ContactType : MemberBaseType<ContactAggregate>
                 var idsList = ids.ToList();
 
                 var membershipRolesTask = organizationMembershipSearchService.GetRolesForUsersInOrgAsync(idsList, organizationId);
-                var globalRolesTask = GetGlobalRolesByUserAsync(idsList, roleManagerFactory, userManagerFactory);
+                var globalRolesTask = GlobalRolesResolver.GetGlobalRolesByUserAsync(idsList, roleManagerFactory, userManagerFactory);
 
                 await Task.WhenAll(membershipRolesTask, globalRolesTask);
 
@@ -390,44 +390,6 @@ public class ContactType : MemberBaseType<ContactAggregate>
 
             return roles.Count > 0 ? roles : null;
         });
-    }
-
-    // Mirrors OrganizationType's global-role check: a user can hold an ASP.NET Identity role
-    // that is not tied to any OrganizationMembership or org-level role assignment
-    private static async Task<IDictionary<string, IReadOnlyCollection<Role>>> GetGlobalRolesByUserAsync(
-        IList<string> userIds,
-        Func<RoleManager<Role>> roleManagerFactory,
-        Func<UserManager<ApplicationUser>> userManagerFactory)
-    {
-        using var roleManager = roleManagerFactory();
-        using var userManager = userManagerFactory();
-
-        // The role set is small — load it once instead of issuing a filtered query per user
-        var rolesByName = roleManager.Roles.ToLookup(r => r.Name);
-
-        var result = new Dictionary<string, IReadOnlyCollection<Role>>();
-
-        foreach (var userId in userIds)
-        {
-            var user = await userManager.FindByIdAsync(userId);
-            if (user == null)
-            {
-                continue;
-            }
-
-            var roleNames = await userManager.GetRolesAsync(user);
-            if (roleNames.Count == 0)
-            {
-                continue;
-            }
-
-            result[userId] = roleNames
-                .SelectMany(roleName => rolesByName[roleName])
-                .Select(r => new Role { Id = r.Id, Name = r.Name })
-                .ToList();
-        }
-
-        return result;
     }
 
     private static List<string> GetSecurityAccountIds(IResolveFieldContext<ContactAggregate> context) =>

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Schemas/InputChangeOrganizationContactRoleType.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Schemas/InputChangeOrganizationContactRoleType.cs
@@ -9,6 +9,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Schemas
         public InputChangeOrganizationContactRoleType()
         {
             Field<NonNullGraphType<StringGraphType>>(nameof(ChangeOrganizationContactRoleCommand.MemberId)).Description("Contact member ID to be changed");
+            Field<StringGraphType>(nameof(ChangeOrganizationContactRoleCommand.StoreId)).Description("ID of store whose company-role whitelist should be used for validation. When omitted, the member's own store is used");
             Field<ListGraphType<NonNullGraphType<StringGraphType>>>(nameof(ChangeOrganizationContactRoleCommand.RoleIds)).Description("Role IDs or names to be assigned to the user within the organization");
         }
     }

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Schemas/OrganizationType.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Schemas/OrganizationType.cs
@@ -56,14 +56,23 @@ public class OrganizationType : MemberBaseType<OrganizationAggregate>
             .Description("Distinct roles currently assigned to at least one member of this organization - " +
                           "membership roles and members' global (account-level) roles alike. Useful for " +
                           "building a members-list role filter that only offers roles with results.")
+            .Argument<StringGraphType>("storeId", "Store ID")
+            .Argument<StringGraphType>("cultureName", "Culture name for localized responses")
             .ResolveAsync(async context => await context.GetMediator().Send(
-                new GetOrganizationContactRolesQuery { OrganizationId = context.Source.Organization.Id }));
+                new GetOrganizationContactRolesQuery
+                {
+                    OrganizationId = context.Source.Organization.Id,
+                    StoreId = context.GetArgument<string>("storeId"),
+                    CultureName = context.GetArgument<string>("cultureName"),
+                }));
 
         var connectionBuilder = GraphTypeExtensionHelper.CreateConnection<ContactType, OrganizationAggregate>("contacts")
             .Argument<StringGraphType>("searchPhrase", "Free text search")
             .Argument<StringGraphType>("sort", "Sort expression")
             .Argument<ListGraphType<StringGraphType>>("roleIds", "Filter contacts by role IDs (org-level, membership, or global)")
             .Argument<ListGraphType<StringGraphType>>("statuses", "Filter contacts by effective status/lock state for this organization (e.g. Approved, Invited, Locked)")
+            .Argument<StringGraphType>("storeId", "Store ID")
+            .Argument<StringGraphType>("cultureName", "Culture name for localized responses")
             .PageSize(20);
 
         connectionBuilder.ResolveAsync(context => ResolveContactsConnectionAsync(context, factory));
@@ -95,11 +104,19 @@ public class OrganizationType : MemberBaseType<OrganizationAggregate>
         query.DeepSearch = false;
 
         var mediator = context.GetMediator();
+        var storeId = context.GetArgument<string>("storeId");
+        var cultureName = context.GetArgument<string>("cultureName");
 
         var roleIds = context.GetArgument<IList<string>>("roleIds");
         if (roleIds is { Count: > 0 })
         {
-            var roleFilter = await mediator.Send(new ResolveOrganizationRoleFilterQuery { OrganizationId = orgId, RoleIds = roleIds });
+            var roleFilter = await mediator.Send(new ResolveOrganizationRoleFilterQuery
+            {
+                OrganizationId = orgId,
+                RoleIds = roleIds,
+                StoreId = storeId,
+                CultureName = cultureName,
+            });
 
             if (roleFilter.FilterRequired)
             {
@@ -115,7 +132,13 @@ public class OrganizationType : MemberBaseType<OrganizationAggregate>
         var statuses = context.GetArgument<IList<string>>("statuses");
         if (statuses is { Count: > 0 })
         {
-            var statusFilter = await mediator.Send(new ResolveOrganizationStatusFilterQuery { OrganizationId = orgId, Statuses = statuses });
+            var statusFilter = await mediator.Send(new ResolveOrganizationStatusFilterQuery
+            {
+                OrganizationId = orgId,
+                Statuses = statuses,
+                StoreId = storeId,
+                CultureName = cultureName,
+            });
 
             if (statusFilter.FilterRequired)
             {
@@ -194,7 +217,7 @@ public class OrganizationType : MemberBaseType<OrganizationAggregate>
             });
     }
 
-    private static List<string> IntersectObjectIds(IList<string> existing, IReadOnlyCollection<string> additional)
+    private static List<string> IntersectObjectIds(IList<string> existing, IList<string> additional)
     {
         return existing == null ? additional.ToList() : existing.Intersect(additional).ToList();
     }

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Schemas/OrganizationType.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Schemas/OrganizationType.cs
@@ -8,9 +8,7 @@ using GraphQL.DataLoader;
 using GraphQL.Types;
 using MediatR;
 using Microsoft.AspNetCore.Identity;
-using Microsoft.EntityFrameworkCore;
 using VirtoCommerce.CustomerModule.Core.Model;
-using VirtoCommerce.CustomerModule.Core.Model.Search;
 using VirtoCommerce.CustomerModule.Core.Services;
 using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Platform.Core.Security;
@@ -19,6 +17,7 @@ using VirtoCommerce.ProfileExperienceApiModule.Data.Aggregates.Contact;
 using VirtoCommerce.ProfileExperienceApiModule.Data.Aggregates.Organization;
 using VirtoCommerce.ProfileExperienceApiModule.Data.Commands;
 using VirtoCommerce.ProfileExperienceApiModule.Data.Extensions;
+using VirtoCommerce.ProfileExperienceApiModule.Data.Queries;
 using VirtoCommerce.ProfileExperienceApiModule.Data.Services;
 using VirtoCommerce.StoreModule.Core.Services;
 using VirtoCommerce.Xapi.Core.Extensions;
@@ -36,9 +35,7 @@ public class OrganizationType : MemberBaseType<OrganizationAggregate>
         IMemberAddressService memberAddressService,
         IMemberAggregateFactory factory,
         IMemberService memberService,
-        IMemberSearchService memberSearchService,
         IOrganizationMembershipSearchService organizationMembershipService,
-        Func<RoleManager<Role>> roleManagerFactory,
         Func<UserManager<ApplicationUser>> userManagerFactory,
         IDataLoaderContextAccessor dataLoader)
         : base(storeService, dynamicPropertyResolverService, memberAddressService)
@@ -55,6 +52,13 @@ public class OrganizationType : MemberBaseType<OrganizationAggregate>
             .Description("Current user's effective status in this organization: the organization-specific override if set, otherwise the contact's global status.")
             .Resolve(context => ResolveMyStatusInOrganization(context, organizationMembershipService, memberService, userManagerFactory, dataLoader));
 
+        Field<ListGraphType<RoleType>>("contactRoles")
+            .Description("Distinct roles currently assigned to at least one member of this organization - " +
+                          "membership roles and members' global (account-level) roles alike. Useful for " +
+                          "building a members-list role filter that only offers roles with results.")
+            .ResolveAsync(async context => await context.GetMediator().Send(
+                new GetOrganizationContactRolesQuery { OrganizationId = context.Source.Organization.Id }));
+
         var connectionBuilder = GraphTypeExtensionHelper.CreateConnection<ContactType, OrganizationAggregate>("contacts")
             .Argument<StringGraphType>("searchPhrase", "Free text search")
             .Argument<StringGraphType>("sort", "Sort expression")
@@ -62,8 +66,7 @@ public class OrganizationType : MemberBaseType<OrganizationAggregate>
             .Argument<ListGraphType<StringGraphType>>("statuses", "Filter contacts by effective status/lock state for this organization (e.g. Approved, Invited, Locked)")
             .PageSize(20);
 
-        connectionBuilder.ResolveAsync(context => ResolveContactsConnectionAsync(
-            context, factory, memberService, memberSearchService, organizationMembershipService, roleManagerFactory, userManagerFactory));
+        connectionBuilder.ResolveAsync(context => ResolveContactsConnectionAsync(context, factory));
         AddField(connectionBuilder.FieldType);
     }
 
@@ -75,73 +78,57 @@ public class OrganizationType : MemberBaseType<OrganizationAggregate>
         IMediator mediator,
         IMemberAggregateFactory factory,
         IMemberService memberService,
-        IMemberSearchService memberSearchService,
         IOrganizationMembershipSearchService organizationMembershipService,
-        Func<RoleManager<Role>> roleManagerFactory,
         Func<UserManager<ApplicationUser>> userManagerFactory,
         IDataLoaderContextAccessor dataLoader)
-        : this(storeService, dynamicPropertyResolverService, memberAddressService, factory, memberService, memberSearchService, organizationMembershipService, roleManagerFactory, userManagerFactory, dataLoader)
+        : this(storeService, dynamicPropertyResolverService, memberAddressService, factory, memberService, organizationMembershipService, userManagerFactory, dataLoader)
     {
     }
 
     private static async Task<object> ResolveContactsConnectionAsync(
         IResolveConnectionContext<OrganizationAggregate> context,
-        IMemberAggregateFactory factory,
-        IMemberService memberService,
-        IMemberSearchService memberSearchService,
-        IOrganizationMembershipSearchService organizationMembershipService,
-        Func<RoleManager<Role>> roleManagerFactory,
-        Func<UserManager<ApplicationUser>> userManagerFactory)
+        IMemberAggregateFactory factory)
     {
         var query = context.GetSearchMembersQuery<SearchContactsQuery>();
         var orgId = context.Source.Organization.Id;
         query.MemberId = orgId;
         query.DeepSearch = false;
 
+        var mediator = context.GetMediator();
+
         var roleIds = context.GetArgument<IList<string>>("roleIds");
         if (roleIds is { Count: > 0 })
         {
-            var (filterRequired, filterIds) = await ResolveRoleFilterAsync(
-                orgId,
-                roleIds,
-                memberService,
-                memberSearchService,
-                organizationMembershipService,
-                roleManagerFactory,
-                userManagerFactory);
+            var roleFilter = await mediator.Send(new ResolveOrganizationRoleFilterQuery { OrganizationId = orgId, RoleIds = roleIds });
 
-            if (filterRequired)
+            if (roleFilter.FilterRequired)
             {
-                if (filterIds.Count == 0)
+                if (roleFilter.Ids.Count == 0)
                 {
                     return new PagedConnection<ContactAggregate>([], query.Skip, query.Take, 0);
                 }
 
-                query.ObjectIds = IntersectObjectIds(query.ObjectIds, filterIds);
+                query.ObjectIds = IntersectObjectIds(query.ObjectIds, roleFilter.Ids);
             }
         }
 
         var statuses = context.GetArgument<IList<string>>("statuses");
         if (statuses is { Count: > 0 })
         {
-            var (filterRequired, filterIds) = await ResolveStatusFilterAsync(
-                orgId,
-                statuses,
-                memberSearchService,
-                organizationMembershipService);
+            var statusFilter = await mediator.Send(new ResolveOrganizationStatusFilterQuery { OrganizationId = orgId, Statuses = statuses });
 
-            if (filterRequired)
+            if (statusFilter.FilterRequired)
             {
-                if (filterIds.Count == 0)
+                if (statusFilter.Ids.Count == 0)
                 {
                     return new PagedConnection<ContactAggregate>([], query.Skip, query.Take, 0);
                 }
 
-                query.ObjectIds = IntersectObjectIds(query.ObjectIds, filterIds);
+                query.ObjectIds = IntersectObjectIds(query.ObjectIds, statusFilter.Ids);
             }
         }
 
-        var response = await context.GetMediator().Send(query);
+        var response = await mediator.Send(query);
 
         return new PagedConnection<ContactAggregate>(
             response.Results.Select(x => factory.Create<ContactAggregate>(x)), query.Skip, query.Take,
@@ -205,169 +192,6 @@ public class OrganizationType : MemberBaseType<OrganizationAggregate>
                 membershipByOrgId.TryGetValue(orgId, out var membership);
                 return OrganizationMembership.ResolveEffectiveStatus(membership?.Status, globalStatus);
             });
-    }
-
-    private static async Task<IReadOnlyCollection<string>> GetContactIdsByGlobalRolesAsync(
-        IList<string> roleIds,
-        IReadOnlyCollection<ApplicationUser> orgUsers,
-        RoleManager<Role> roleManager,
-        UserManager<ApplicationUser> userManager)
-    {
-        var requestedRoleNames = await roleManager.Roles
-            .Where(r => roleIds.Contains(r.Id))
-            .Select(r => r.Name)
-            .ToListAsync();
-
-        if (requestedRoleNames.Count == 0)
-        {
-            return [];
-        }
-
-        var requestedRoleNameSet = requestedRoleNames.ToHashSet(StringComparer.OrdinalIgnoreCase);
-        var result = new List<string>();
-
-        foreach (var user in orgUsers)
-        {
-            var userRoleNames = await userManager.GetRolesAsync(user);
-            if (userRoleNames.Any(requestedRoleNameSet.Contains))
-            {
-                var contactId = user.MemberId ?? user.Id;
-                if (!string.IsNullOrEmpty(contactId))
-                {
-                    result.Add(contactId);
-                }
-            }
-        }
-
-        return result;
-    }
-
-    private static async Task<(bool filterRequired, IReadOnlyCollection<string> ids)> ResolveRoleFilterAsync(
-        string orgId,
-        IList<string> roleIds,
-        IMemberService memberService,
-        IMemberSearchService memberSearchService,
-        IOrganizationMembershipSearchService organizationMembershipService,
-        Func<RoleManager<Role>> roleManagerFactory,
-        Func<UserManager<ApplicationUser>> userManagerFactory)
-    {
-        var organization = await memberService.GetByIdAsync(orgId, memberType: nameof(Organization)) as Organization;
-        var orgRoleIds = organization?.Roles?.Select(r => r.RoleId).ToHashSet() ?? [];
-
-        if (roleIds.Any(orgRoleIds.Contains))
-        {
-            return (filterRequired: false, ids: []);
-        }
-
-        var membershipsTask = organizationMembershipService.SearchAllNoCloneAsync(
-            new OrganizationMembershipSearchCriteria { OrganizationId = orgId });
-        var contactsTask = memberSearchService.SearchAllAsync(
-            new MembersSearchCriteria { MemberId = orgId });
-
-        await Task.WhenAll(membershipsTask, contactsTask);
-
-        var allOrgMemberships = membershipsTask.Result;
-        var orgMembershipUserIds = allOrgMemberships.Select(m => m.UserId).ToHashSet();
-        var orgContactIds = contactsTask.Result.Select(c => c.Id).ToHashSet();
-
-        List<ApplicationUser> orgUsers;
-        using (var um = userManagerFactory())
-        {
-            orgUsers = await um.Users
-                .Where(u => orgMembershipUserIds.Contains(u.Id) ||
-                            (!string.IsNullOrEmpty(u.MemberId) && orgContactIds.Contains(u.MemberId)))
-                .ToListAsync();
-        }
-
-        if (orgUsers.Count == 0)
-        {
-            return (filterRequired: true, ids: []);
-        }
-
-        var membershipUserIds = allOrgMemberships
-            .Where(m => m.Roles?.Any(r => roleIds.Contains(r.RoleId)) == true)
-            .Select(m => m.UserId)
-            .ToHashSet();
-
-        using var globalRoleManager = roleManagerFactory();
-        using var globalUserManager = userManagerFactory();
-        var qualifyingContactIds = (await GetContactIdsByGlobalRolesAsync(roleIds, orgUsers, globalRoleManager, globalUserManager))
-            .ToHashSet();
-
-        qualifyingContactIds.UnionWith(
-            orgUsers
-                .Where(u => membershipUserIds.Contains(u.Id))
-                .Select(u => u.MemberId ?? u.Id)
-                .Where(id => !string.IsNullOrEmpty(id)));
-
-        return (filterRequired: true, ids: qualifyingContactIds);
-    }
-
-    private const string LockedFilterValue = "Locked";
-
-    private static async Task<(bool filterRequired, IReadOnlyCollection<string> ids)> ResolveStatusFilterAsync(
-        string orgId,
-        IList<string> statuses,
-        IMemberSearchService memberSearchService,
-        IOrganizationMembershipSearchService organizationMembershipService)
-    {
-        var membershipsTask = organizationMembershipService.SearchAllNoCloneAsync(
-            new OrganizationMembershipSearchCriteria { OrganizationId = orgId });
-        var contactsTask = memberSearchService.SearchAllAsync(
-            new MembersSearchCriteria { MemberId = orgId });
-
-        await Task.WhenAll(membershipsTask, contactsTask);
-
-        var membershipByUserId = membershipsTask.Result
-            .GroupBy(m => m.UserId)
-            .ToDictionary(g => g.Key, g => g.First());
-
-        var wantsLocked = statuses.Contains(LockedFilterValue);
-        var lifecycleStatuses = statuses.Where(s => s != LockedFilterValue).ToHashSet();
-
-        var qualifyingContactIds = contactsTask.Result
-            .Where(contact => ContactMatchesStatusFilter(contact, membershipByUserId, wantsLocked, lifecycleStatuses))
-            .Select(contact => contact.Id)
-            .ToHashSet();
-
-        return (filterRequired: true, ids: qualifyingContactIds);
-    }
-
-    private static bool ContactMatchesStatusFilter(
-        Member contact, IDictionary<string, OrganizationMembership> membershipByUserId, bool wantsLocked, HashSet<string> lifecycleStatuses)
-    {
-        var membership = FindMembership(contact, membershipByUserId);
-
-        if (membership?.IsCurrentlyLocked == true)
-        {
-            return wantsLocked;
-        }
-
-        if (lifecycleStatuses.Count == 0)
-        {
-            return false;
-        }
-
-        var effectiveStatus = OrganizationMembership.ResolveEffectiveStatus(membership?.Status, contact.Status);
-
-        return !string.IsNullOrEmpty(effectiveStatus) && lifecycleStatuses.Contains(effectiveStatus);
-    }
-
-    private static OrganizationMembership FindMembership(Member contact, IDictionary<string, OrganizationMembership> membershipByUserId)
-    {
-        var securityAccountIds = (contact as IHasSecurityAccounts)?.SecurityAccounts?
-            .Select(sa => sa.Id)
-            .Where(id => !string.IsNullOrEmpty(id)) ?? [];
-
-        foreach (var securityAccountId in securityAccountIds)
-        {
-            if (membershipByUserId.TryGetValue(securityAccountId, out var membership))
-            {
-                return membership;
-            }
-        }
-
-        return null;
     }
 
     private static List<string> IntersectObjectIds(IList<string> existing, IReadOnlyCollection<string> additional)

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Services/GlobalRolesResolver.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Services/GlobalRolesResolver.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Identity;
+using VirtoCommerce.Platform.Core.Security;
+
+namespace VirtoCommerce.ProfileExperienceApiModule.Data.Services;
+
+/// <summary>
+/// Resolves a user's global (account-level) ASP.NET Identity roles - the roles a user holds
+/// directly, not tied to any OrganizationMembership or org-level role assignment. Shared between
+/// ContactType.rolesInOrganization and the organization contact-roles/role-filter query handlers,
+/// which all need to fold the same global roles into their respective per-member role sets.
+/// </summary>
+public static class GlobalRolesResolver
+{
+    public static async Task<IDictionary<string, IReadOnlyCollection<Role>>> GetGlobalRolesByUserAsync(
+        IList<string> userIds,
+        Func<RoleManager<Role>> roleManagerFactory,
+        Func<UserManager<ApplicationUser>> userManagerFactory)
+    {
+        using var roleManager = roleManagerFactory();
+        using var userManager = userManagerFactory();
+
+        var rolesByName = roleManager.Roles.ToLookup(r => r.Name);
+
+        var result = new Dictionary<string, IReadOnlyCollection<Role>>();
+
+        foreach (var userId in userIds)
+        {
+            var user = await userManager.FindByIdAsync(userId);
+            if (user == null)
+            {
+                continue;
+            }
+
+            var roleNames = await userManager.GetRolesAsync(user);
+            if (roleNames.Count == 0)
+            {
+                continue;
+            }
+
+            result[userId] = roleNames
+                .SelectMany(roleName => rolesByName[roleName])
+                .Select(r => new Role { Id = r.Id, Name = r.Name })
+                .ToList();
+        }
+
+        return result;
+    }
+}

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Services/GlobalRolesResolver.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Services/GlobalRolesResolver.cs
@@ -15,7 +15,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Data.Services;
 /// </summary>
 public static class GlobalRolesResolver
 {
-    public static async Task<IDictionary<string, IReadOnlyCollection<Role>>> GetGlobalRolesByUserAsync(
+    public static async Task<IDictionary<string, IList<Role>>> GetGlobalRolesByUserAsync(
         IList<string> userIds,
         Func<RoleManager<Role>> roleManagerFactory,
         Func<UserManager<ApplicationUser>> userManagerFactory)
@@ -25,7 +25,7 @@ public static class GlobalRolesResolver
 
         var rolesByName = roleManager.Roles.ToLookup(r => r.Name);
 
-        var result = new Dictionary<string, IReadOnlyCollection<Role>>();
+        var result = new Dictionary<string, IList<Role>>();
 
         foreach (var userId in userIds)
         {

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/Services/OrganizationUsersResolver.cs
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/Services/OrganizationUsersResolver.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using VirtoCommerce.CustomerModule.Core.Model;
+using VirtoCommerce.Platform.Core.Security;
+
+namespace VirtoCommerce.ProfileExperienceApiModule.Data.Services;
+
+/// <summary>
+/// Resolves the ApplicationUser accounts that belong to an organization - the union of users with
+/// an OrganizationMembership row and users whose account is directly linked to one of the org's
+/// contacts. Shared between GetOrganizationContactRolesQueryHandler and
+/// ResolveOrganizationRoleFilterQueryHandler, which both need this same set before resolving roles.
+/// </summary>
+public static class OrganizationUsersResolver
+{
+    public static async Task<List<ApplicationUser>> GetOrganizationUsersAsync(
+        IList<OrganizationMembership> memberships,
+        IList<Member> contacts,
+        Func<UserManager<ApplicationUser>> userManagerFactory)
+    {
+        var orgMembershipUserIds = memberships.Select(m => m.UserId).ToHashSet();
+        var orgContactIds = contacts.Select(c => c.Id).ToHashSet();
+
+        using var userManager = userManagerFactory();
+
+        return await userManager.Users
+            .Where(u => orgMembershipUserIds.Contains(u.Id) ||
+                        (!string.IsNullOrEmpty(u.MemberId) && orgContactIds.Contains(u.MemberId)))
+            .ToListAsync();
+    }
+}

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/VirtoCommerce.ProfileExperienceApiModule.Data.csproj
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/VirtoCommerce.ProfileExperienceApiModule.Data.csproj
@@ -7,7 +7,10 @@
     <SonarQubeTestProject>false</SonarQubeTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="VirtoCommerce.CustomerModule.Core" Version="3.1021.0" />
+    <!-- TEMPORARY local-dev workaround (VCST-5281): points at a sibling checkout of vc-module-customer
+         while ICompanyMemberRoleService is unreleased. Revert to a PackageReference once a
+         VirtoCommerce.CustomerModule.Core package containing it is published. -->
+    <ProjectReference Include="..\..\..\vc-module-customer\src\VirtoCommerce.CustomerModule.Core\VirtoCommerce.CustomerModule.Core.csproj" />
     <PackageReference Include="VirtoCommerce.MarketingModule.Core" Version="3.1005.0" />
     <PackageReference Include="VirtoCommerce.NotificationsModule.Core" Version="3.1009.0" />
     <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.1039.0" />

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/VirtoCommerce.ProfileExperienceApiModule.Data.csproj
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/VirtoCommerce.ProfileExperienceApiModule.Data.csproj
@@ -7,10 +7,7 @@
     <SonarQubeTestProject>false</SonarQubeTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <!-- TEMPORARY local-dev workaround (VCST-5281): points at a sibling checkout of vc-module-customer
-         while ICompanyMemberRoleService is unreleased. Revert to a PackageReference once a
-         VirtoCommerce.CustomerModule.Core package containing it is published. -->
-    <ProjectReference Include="..\..\..\vc-module-customer\src\VirtoCommerce.CustomerModule.Core\VirtoCommerce.CustomerModule.Core.csproj" />
+    <PackageReference Include="VirtoCommerce.CustomerModule.Core" Version="3.1023.0-alpha.1007-vcst-5450" />
     <PackageReference Include="VirtoCommerce.MarketingModule.Core" Version="3.1005.0" />
     <PackageReference Include="VirtoCommerce.NotificationsModule.Core" Version="3.1009.0" />
     <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.1039.0" />

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Data/VirtoCommerce.ProfileExperienceApiModule.Data.csproj
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Data/VirtoCommerce.ProfileExperienceApiModule.Data.csproj
@@ -7,7 +7,7 @@
     <SonarQubeTestProject>false</SonarQubeTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="VirtoCommerce.CustomerModule.Core" Version="3.1023.0-alpha.1007-vcst-5450" />
+    <PackageReference Include="VirtoCommerce.CustomerModule.Core" Version="3.1023.0-alpha.1009-vcst-5450" />
     <PackageReference Include="VirtoCommerce.MarketingModule.Core" Version="3.1005.0" />
     <PackageReference Include="VirtoCommerce.NotificationsModule.Core" Version="3.1009.0" />
     <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.1039.0" />

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Web/module.manifest
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Web/module.manifest
@@ -6,7 +6,7 @@
 
   <platformVersion>3.1039.0</platformVersion>
   <dependencies>
-    <dependency id="VirtoCommerce.Customer" version="3.1023.0-alpha.1007-vcst-5450" />
+    <dependency id="VirtoCommerce.Customer" version="3.1023.0-alpha.1009-vcst-5450" />
     <dependency id="VirtoCommerce.Marketing" version="3.1005.0" optional="true" />
     <dependency id="VirtoCommerce.Notifications" version="3.1009.0" />
     <dependency id="VirtoCommerce.Pricing" version="3.1003.0" optional="true" />

--- a/src/VirtoCommerce.ProfileExperienceApiModule.Web/module.manifest
+++ b/src/VirtoCommerce.ProfileExperienceApiModule.Web/module.manifest
@@ -6,7 +6,7 @@
 
   <platformVersion>3.1039.0</platformVersion>
   <dependencies>
-    <dependency id="VirtoCommerce.Customer" version="3.1021.0" />
+    <dependency id="VirtoCommerce.Customer" version="3.1023.0-alpha.1007-vcst-5450" />
     <dependency id="VirtoCommerce.Marketing" version="3.1005.0" optional="true" />
     <dependency id="VirtoCommerce.Notifications" version="3.1009.0" />
     <dependency id="VirtoCommerce.Pricing" version="3.1003.0" optional="true" />

--- a/tests/VirtoCommerce.ProfileExperienceApiModule.Tests/Handlers/ChangeOrganizationContactRoleCommandHandlerTests.cs
+++ b/tests/VirtoCommerce.ProfileExperienceApiModule.Tests/Handlers/ChangeOrganizationContactRoleCommandHandlerTests.cs
@@ -22,6 +22,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Tests.Handlers
         private readonly Mock<IOrganizationMembershipSearchService> _membershipSearchServiceMock = new();
         private readonly Mock<UserManager<ApplicationUser>> _userManagerMock;
         private readonly Mock<RoleManager<Role>> _roleManagerMock;
+        private readonly Mock<ICompanyMemberRoleService> _companyMemberRoleServiceMock = new();
 
         public ChangeOrganizationContactRoleCommandHandlerTests()
         {
@@ -30,6 +31,10 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Tests.Handlers
 
             _roleManagerMock = new Mock<RoleManager<Role>>(
                 new Mock<IRoleStore<Role>>().Object, null, null, null, null);
+
+            _companyMemberRoleServiceMock
+                .Setup(x => x.GetAllowedRoleIdsAsync(It.IsAny<string>()))
+                .ReturnsAsync(["role-1"]);
         }
 
         [Fact]
@@ -164,6 +169,44 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Tests.Handlers
                 Times.Once);
         }
 
+        [Fact]
+        public async Task Handle_RoleNotInWhitelist_ReturnsRoleNotAllowedError()
+        {
+            // Arrange
+            const string securityUserId = "user-1";
+
+            SetupContactAggregate(securityUserId);
+
+            _userManagerMock
+                .Setup(x => x.FindByIdAsync(securityUserId))
+                .ReturnsAsync(new ApplicationUser { Id = securityUserId, UserName = "test@test.com", StoreId = "store-1" });
+
+            _roleManagerMock
+                .Setup(x => x.FindByIdAsync("role-not-allowed"))
+                .ReturnsAsync(new Role { Id = "role-not-allowed", Name = "role-not-allowed", NormalizedName = "ROLE-NOT-ALLOWED" });
+
+            _companyMemberRoleServiceMock
+                .Setup(x => x.GetAllowedRoleIdsAsync("store-1"))
+                .ReturnsAsync(["role-1"]);
+
+            var handler = BuildHandler();
+            var command = new ChangeOrganizationContactRoleCommand
+            {
+                MemberId = "contact-1",
+                OrganizationId = "org-1",
+                RoleIds = ["role-not-allowed"]
+            };
+
+            // Act
+            var result = await handler.Handle(command, CancellationToken.None);
+
+            // Assert
+            Assert.False(result.Succeeded);
+            Assert.Contains(result.Errors, e => e.Code == "RoleNotAllowed" && e.Parameter == "role-not-allowed");
+
+            _membershipServiceMock.Verify(x => x.SaveChangesAsync(It.IsAny<IList<OrganizationMembership>>()), Times.Never);
+        }
+
         private void SetupContactAggregate(string securityUserId)
         {
             var contact = new Contact
@@ -186,6 +229,7 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Tests.Handlers
                 _membershipServiceMock.Object,
                 _membershipSearchServiceMock.Object,
                 _contactRepoMock.Object,
+                _companyMemberRoleServiceMock.Object,
                 Options.Create(new AuthorizationOptions()));
         }
     }

--- a/tests/VirtoCommerce.ProfileExperienceApiModule.Tests/Handlers/ResolveOrganizationRoleFilterQueryHandlerTests.cs
+++ b/tests/VirtoCommerce.ProfileExperienceApiModule.Tests/Handlers/ResolveOrganizationRoleFilterQueryHandlerTests.cs
@@ -1,0 +1,84 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Identity;
+using Moq;
+using VirtoCommerce.CustomerModule.Core.Model;
+using VirtoCommerce.CustomerModule.Core.Services;
+using VirtoCommerce.Platform.Core.Security;
+using VirtoCommerce.ProfileExperienceApiModule.Data.Queries;
+using Xunit;
+
+namespace VirtoCommerce.ProfileExperienceApiModule.Tests.Handlers;
+
+public class ResolveOrganizationRoleFilterQueryHandlerTests
+{
+    private const string OrgId = "org-1";
+
+    private readonly Mock<IMemberService> _memberServiceMock = new();
+    private readonly Mock<IMemberSearchService> _memberSearchServiceMock = new();
+    private readonly Mock<IOrganizationMembershipSearchService> _organizationMembershipServiceMock = new();
+    private readonly Mock<RoleManager<Role>> _roleManagerMock;
+    private readonly Mock<UserManager<ApplicationUser>> _userManagerMock;
+
+    public ResolveOrganizationRoleFilterQueryHandlerTests()
+    {
+        _roleManagerMock = new Mock<RoleManager<Role>>(
+            new Mock<IRoleStore<Role>>().Object, null, null, null, null);
+        _userManagerMock = new Mock<UserManager<ApplicationUser>>(
+            new Mock<IUserStore<ApplicationUser>>().Object, null, null, null, null, null, null, null, null);
+    }
+
+    private ResolveOrganizationRoleFilterQueryHandler BuildHandler() => new(
+        _memberServiceMock.Object,
+        _memberSearchServiceMock.Object,
+        _organizationMembershipServiceMock.Object,
+        () => _roleManagerMock.Object,
+        () => _userManagerMock.Object);
+
+    [Fact]
+    public async Task Handle_RequestedRoleIsAnOrganizationLevelRole_SkipsFilteringEntirely()
+    {
+        // Arrange - the org itself has this role assigned (CustomerOrganizationRole), so every member
+        // qualifies and the (expensive) per-member role resolution can be skipped entirely.
+        _memberServiceMock
+            .Setup(x => x.GetByIdAsync(OrgId, null, nameof(Organization)))
+            .ReturnsAsync(new Organization
+            {
+                Id = OrgId,
+                Roles = [new OrganizationRole { RoleId = "org-role-1", RoleName = "Warranty Specialist" }],
+            });
+
+        var handler = BuildHandler();
+        var query = new ResolveOrganizationRoleFilterQuery { OrganizationId = OrgId, RoleIds = ["Warranty Specialist"] };
+
+        // Act
+        var result = await handler.Handle(query, CancellationToken.None);
+
+        // Assert - no filtering needed, and no membership/user search was ever attempted
+        Assert.False(result.FilterRequired);
+        _organizationMembershipServiceMock.Verify(
+            x => x.SearchAsync(It.IsAny<OrganizationMembershipSearchCriteria>(), It.IsAny<bool>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_RequestedRoleMatchesOrgLevelRoleId_CaseInsensitive()
+    {
+        // Arrange - same as above but matching by Id (not Name) and differing only in case
+        _memberServiceMock
+            .Setup(x => x.GetByIdAsync(OrgId, null, nameof(Organization)))
+            .ReturnsAsync(new Organization
+            {
+                Id = OrgId,
+                Roles = [new OrganizationRole { RoleId = "Org-Role-1", RoleName = "Warranty Specialist" }],
+            });
+
+        var handler = BuildHandler();
+        var query = new ResolveOrganizationRoleFilterQuery { OrganizationId = OrgId, RoleIds = ["org-role-1"] };
+
+        // Act
+        var result = await handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        Assert.False(result.FilterRequired);
+    }
+}

--- a/tests/VirtoCommerce.ProfileExperienceApiModule.Tests/Handlers/ResolveOrganizationStatusFilterQueryHandlerTests.cs
+++ b/tests/VirtoCommerce.ProfileExperienceApiModule.Tests/Handlers/ResolveOrganizationStatusFilterQueryHandlerTests.cs
@@ -1,0 +1,108 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using VirtoCommerce.CustomerModule.Core;
+using VirtoCommerce.CustomerModule.Core.Model;
+using VirtoCommerce.CustomerModule.Core.Model.Search;
+using VirtoCommerce.CustomerModule.Core.Services;
+using VirtoCommerce.Platform.Core.Security;
+using VirtoCommerce.ProfileExperienceApiModule.Data.Queries;
+using Xunit;
+
+namespace VirtoCommerce.ProfileExperienceApiModule.Tests.Handlers;
+
+public class ResolveOrganizationStatusFilterQueryHandlerTests
+{
+    private const string OrgId = "org-1";
+
+    private readonly Mock<IMemberSearchService> _memberSearchServiceMock = new();
+    private readonly Mock<IOrganizationMembershipSearchService> _membershipSearchServiceMock = new();
+
+    private ResolveOrganizationStatusFilterQueryHandler BuildHandler() =>
+        new(_memberSearchServiceMock.Object, _membershipSearchServiceMock.Object);
+
+    private void SetupSearches(IList<Contact> contacts, IList<OrganizationMembership> memberships)
+    {
+        _memberSearchServiceMock
+            .Setup(x => x.SearchAllAsync(It.IsAny<MembersSearchCriteria>()))
+            .ReturnsAsync(contacts.Cast<Member>().ToList());
+
+        _membershipSearchServiceMock
+            .Setup(x => x.SearchAsync(It.IsAny<OrganizationMembershipSearchCriteria>(), It.IsAny<bool>()))
+            .ReturnsAsync(new OrganizationMembershipSearchResult { Results = memberships, TotalCount = memberships.Count });
+    }
+
+    [Fact]
+    public async Task Handle_NoMembership_UsesContactGlobalStatus()
+    {
+        // Arrange - no OrganizationMembership row for this contact's user, so the effective status
+        // falls back to the contact's own global status (ResolveEffectiveStatus semantics)
+        var contact = new Contact
+        {
+            Id = "contact-1",
+            Status = ModuleConstants.MembershipStatuses.Approved,
+            SecurityAccounts = [new ApplicationUser { Id = "user-1" }],
+        };
+        SetupSearches([contact], []);
+
+        var handler = BuildHandler();
+        var query = new ResolveOrganizationStatusFilterQuery { OrganizationId = OrgId, Statuses = [ModuleConstants.MembershipStatuses.Approved] };
+
+        // Act
+        var result = await handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.FilterRequired);
+        Assert.Contains("contact-1", result.Ids);
+    }
+
+    [Fact]
+    public async Task Handle_MembershipStatusOverridesContactStatus()
+    {
+        // Arrange - membership has its own status override that differs from the contact's global one
+        var contact = new Contact
+        {
+            Id = "contact-1",
+            Status = ModuleConstants.MembershipStatuses.Rejected,
+            SecurityAccounts = [new ApplicationUser { Id = "user-1" }],
+        };
+        var membership = new OrganizationMembership { UserId = "user-1", Status = ModuleConstants.MembershipStatuses.Approved };
+        SetupSearches([contact], [membership]);
+
+        var handler = BuildHandler();
+        var query = new ResolveOrganizationStatusFilterQuery { OrganizationId = OrgId, Statuses = [ModuleConstants.MembershipStatuses.Approved] };
+
+        // Act
+        var result = await handler.Handle(query, CancellationToken.None);
+
+        // Assert - matches the membership's Approved override, not the contact's Rejected global status
+        Assert.Contains("contact-1", result.Ids);
+    }
+
+    [Fact]
+    public async Task Handle_LockedFilter_MatchesOnlyCurrentlyLockedMemberships()
+    {
+        // Arrange - one locked, one unlocked-but-otherwise-matching-status membership
+        var lockedContact = new Contact { Id = "contact-locked", SecurityAccounts = [new ApplicationUser { Id = "user-locked" }] };
+        var unlockedContact = new Contact
+        {
+            Id = "contact-unlocked",
+            Status = ModuleConstants.MembershipStatuses.Approved,
+            SecurityAccounts = [new ApplicationUser { Id = "user-unlocked" }],
+        };
+        var lockedMembership = new OrganizationMembership { UserId = "user-locked", IsLocked = true };
+        SetupSearches([lockedContact, unlockedContact], [lockedMembership]);
+
+        var handler = BuildHandler();
+        var query = new ResolveOrganizationStatusFilterQuery { OrganizationId = OrgId, Statuses = ["Locked"] };
+
+        // Act
+        var result = await handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        Assert.Contains("contact-locked", result.Ids);
+        Assert.DoesNotContain("contact-unlocked", result.Ids);
+    }
+}

--- a/tests/VirtoCommerce.ProfileExperienceApiModule.Tests/Schemas/OrganizationTypeTests.cs
+++ b/tests/VirtoCommerce.ProfileExperienceApiModule.Tests/Schemas/OrganizationTypeTests.cs
@@ -39,18 +39,13 @@ namespace VirtoCommerce.ProfileExperienceApiModule.Tests.Schemas
                 new Mock<IUserStore<ApplicationUser>>().Object, null, null, null, null, null, null, null, null);
             _userManagerMock.Setup(x => x.FindByIdAsync(UserId)).ReturnsAsync(new ApplicationUser { Id = UserId, MemberId = MemberId });
 
-            var roleManagerMock = new Mock<RoleManager<Role>>(
-                new Mock<IRoleStore<Role>>().Object, null, null, null, null);
-
             _organizationType = new OrganizationType(
                 new Mock<IStoreService>().Object,
                 new Mock<IDynamicPropertyResolverService>().Object,
                 new Mock<IMemberAddressService>().Object,
                 new Mock<IMemberAggregateFactory>().Object,
                 _memberServiceMock.Object,
-                new Mock<IMemberSearchService>().Object,
                 _membershipSearchServiceMock.Object,
-                () => roleManagerMock.Object,
                 () => _userManagerMock.Object,
                 new DataLoaderContextAccessor { Context = new DataLoaderContext() });
         }


### PR DESCRIPTION
## Description
Enforces the new company-member-role whitelist (from vc-module-customer) on the GraphQL/XAPI surface used by the storefront, and adds a query to expose the roles actually in use within an organization for member-list filtering.

## What was added
- **`ChangeOrganizationContactRoleCommandHandler`**: role assignment now resolves the store's allowed roles via `ICompanyMemberRoleService` and rejects any role not in the whitelist with a `RoleNotAllowed` error.
- **New query `GetOrganizationContactRolesQuery`**: returns the distinct set of roles currently held by an organization's members (membership-level, org-level, and global roles combined) — populates the "role" filter facet on the company members list. Exposed via the `contactRoles` field on `Organization`.
- **New queries `ResolveOrganizationRoleFilterQuery` / `ResolveOrganizationStatusFilterQuery`**: extracted from `OrganizationType`'s resolver-embedded logic into MediatR query/handler pairs, used by `organization.contacts` search to filter results to only members holding an allowed role/status.
- **Refactor**: moved contact-role resolution, global-role resolution (`GlobalRolesResolver`), and org-user resolution (`OrganizationUsersResolver`, dedups logic previously copy-pasted across two handlers) out of `OrganizationType.cs`, following the module's existing MediatR query/handler convention.
- **Scaffolding for future localization**: `storeId` / `cultureName` are now threaded as GraphQL arguments and query/command properties through `contactRoles`, `organization.contacts` (role/status filters), and `changeOrganizationContactRole` — not consumed yet, but in place so future per-store/localized behavior doesn't need another signature change.

## Breaking changes
- `OrganizationType` constructor trimmed from 10 to 8 parameters (removed unused `memberSearchService`, `roleManagerFactory`) — both the primary and `[Obsolete]` constructors updated. Breaks manual instantiation or explicit DI overrides using the old signature. The GraphQL schema/API surface itself is unaffected (additive only).
- `ChangeOrganizationContactRoleCommandHandler.ResolveRoles(string[] roleIds, IdentityResultResponse result)` → `ResolveRoles(string[] roleIds, string storeId, IdentityResultResponse result)` (`protected virtual`) — needed to know the store scope for whitelist validation; breaks external overrides of this method.

## Tests
- `ChangeOrganizationContactRoleCommandHandlerTests`, `ResolveOrganizationRoleFilterQueryHandlerTests`, `ResolveOrganizationStatusFilterQueryHandlerTests` (new)
- Full suite: 112/112 passing

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5450
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.ProfileExperienceApiModule_3.1016.0-pr-143-be8e.zip